### PR TITLE
Bug fixes + improvements

### DIFF
--- a/env-nompi.yaml
+++ b/env-nompi.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
     - h5flow>=0.1.0
     - adc64format>=0.0.2
+    - pylandau

--- a/env.yaml
+++ b/env.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
     - h5flow>=0.1.0
     - adc64format>=0.0.2
+    - pylandau

--- a/scripts/map_file.py
+++ b/scripts/map_file.py
@@ -6,37 +6,6 @@ from math import sqrt
 
 filename = sys.argv[1]
 
-nodes = []
-edges = []
-def add_node_or_edge(name, obj):
-    global nodes
-    global edges
-    name = name.strip('/')
-    print(name)
-    if name[-4:] == '/ref':
-        if isinstance(obj, h5py.Dataset):
-            # path is a reference dataset
-            edge = [n.strip('/') for n in name.split('/ref')]
-            edges.append((edge[1], edge[0]))
-    elif name[-5:] == '/data':
-        if isinstance(obj, h5py.Dataset):
-            # path is a reference dataset
-            attr = dict(shape=obj.shape, nbytes=obj.nbytes)
-            nodes.append((name[:-5], attr))
-    elif 'classname' in obj.attrs:
-        nodes.append((name, dict(classname=obj.attrs['classname'] + f' {obj.attrs["class_version"]}')))
-    elif not '/ref' in name:
-        nodes.append((name, dict()))
-
-with h5py.File(filename,'r') as f:
-    f.visititems(add_node_or_edge)
-
-graph = nx.MultiDiGraph()
-for node in nodes:
-    graph.add_node(node[0], **node[1])
-for edge in edges:
-    graph.add_edge(edge[0], edge[1])
-
 def format_bytes(nbytes):
     if nbytes > 1e9:
         return f'{nbytes/1e9:0.1f}GB'
@@ -46,9 +15,46 @@ def format_bytes(nbytes):
         return f'{nbytes/1e3:0.1f}kB'
     return f'{nbytes}B'
 
+nodes = []
+edges = []
+def add_node_or_edge(name, obj):
+    global nodes
+    global edges
+    name = name.strip('/')
+    if name[-4:] == '/ref':
+        if isinstance(obj, h5py.Dataset):
+            # path is a reference dataset
+            edge = [n.strip('/') for n in name.split('/ref')]
+            attr = dict(shape=obj.shape[:1], nbytes=obj.nbytes)
+            print('\t', attr['shape'], '\t', format_bytes(attr['nbytes']), '\t', name)
+            edges.append(((edge[1], edge[0]), attr))
+    elif name[-5:] == '/data':
+        if isinstance(obj, h5py.Dataset):
+            # path is a dataset
+            attr = dict(shape=obj.shape, nbytes=obj.nbytes)
+            print('\t', attr['shape'], '\t', format_bytes(attr['nbytes']), '\t', name)
+            nodes.append((name[:-5], attr))
+    elif 'classname' in obj.attrs:
+        print(name)
+        nodes.append((name, dict(classname=obj.attrs['classname'] + f' {obj.attrs["class_version"]}')))
+    elif not '/ref' in name:
+        print(name)
+        nodes.append((name, dict()))
+
+with h5py.File(filename,'r') as f:
+    f.visititems(add_node_or_edge)
+
+graph = nx.DiGraph()
+for node in nodes:
+    graph.add_node(node[0], **node[1])
+for edge in edges:
+    graph.add_edge(edge[0][0], edge[0][1], **edge[1])
+
 labels = dict([(node, node+'\n'+'\n'.join([
     str(attr[key]) if key != 'nbytes' else format_bytes(attr[key]) for key in attr]) + '\n' + '\n'*len(attr))
     for node,attr in graph.nodes.items()])
+edge_labels = dict([(edge, f'{attr["shape"]}\n{format_bytes(attr["nbytes"])}')
+    for edge,attr in graph.edges.items()])
 
 # generate plots
 root_paths = set()
@@ -59,12 +65,24 @@ for root in root_paths:
     plt.figure()
     subgraph = nx.subgraph_view(graph, filter_node=(lambda n: root in n or any(root in v or root in u for u,v in graph.edges(n))))
     sublabels = dict([(n, labels[n]) for n in subgraph.nodes])
+    subedgelabels = dict([(e, edge_labels[e]) for e in subgraph.edges])
     pos = nx.circular_layout(subgraph)
-    nx.draw_networkx(subgraph,
+    #nx.draw_networkx(subgraph,
+    #    pos=pos,
+    #    with_labels=True,
+    #    node_color=[(0,0,0,0)],
+    #    labels=sublabels)
+    nx.draw_networkx_nodes(subgraph,
         pos=pos,
-        with_labels=True,
-        node_color=[(0,0,0,0)],
+        node_color=[(0,0,0,0)])
+    nx.draw_networkx_labels(subgraph,
+        pos=pos,
         labels=sublabels)
+    nx.draw_networkx_edges(subgraph,
+        pos=pos)
+    nx.draw_networkx_edge_labels(subgraph,
+                                 pos,
+                                 subedgelabels)
     plt.title(filename+'/'+root)
     plt.tight_layout()
 plt.show()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(name='module0_flow',
                      'scipy',
                      'scikit-image',
                      'scikit-learn',
-                     'h5flow>=0.2.0'
+                     'h5flow>=0.2.0',
+                     'pylandau',
                  ]
                  )

--- a/src/module0_flow/analysis/background_id.py
+++ b/src/module0_flow/analysis/background_id.py
@@ -1,0 +1,241 @@
+import numpy as np
+import numpy.ma as ma
+import os
+import scipy.ndimage as ndimage
+import logging
+
+from h5flow import H5FLOW_MPI
+from h5flow.core import H5FlowStage, resources
+
+from module0_flow.util import units
+from module0_flow.analysis.michel_id import load_likelihood_pdf
+
+
+def fill_likelihood_pdf(cos_mu, d, sig_label, pdf_sig, pdf_bkg,
+                        cos_mu_bins, d_bins):
+    v = np.concatenate(
+        [np.expand_dims(cos_mu.ravel(), -1), np.expand_dims(d.ravel(), -1)], axis=-1)
+
+    sig = pdf_sig + np.histogramdd(v[sig_label], (cos_mu_bins, d_bins))[0]
+    bkg = pdf_bkg + np.histogramdd(v[~sig_label], (cos_mu_bins, d_bins))[0]
+
+    return sig, bkg
+
+
+def bkg_likelihood_score(cos_mu, d, pdf_sig, pdf_bkg,
+                            cos_mu_bins, d_bins):
+    cos_mu_i = np.clip(np.digitize(cos_mu, cos_mu_bins)-1, 0, len(cos_mu_bins)-2)
+    d_i = np.clip(np.digitize(d, d_bins)-1, 0, len(d_bins)-2)
+
+    p_sig = pdf_sig[cos_mu_i, d_i]
+    p_bkg = pdf_bkg[cos_mu_i, d_i]
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        score = np.log(p_sig) - np.log(p_bkg)
+        if np.any(p_bkg > 0):
+            score[p_bkg == 0] = (np.log(p_sig)-np.log(p_bkg[p_bkg>0].min()))[p_bkg == 0]
+        if np.any(p_sig > 0):
+            score[p_sig == 0] = (np.log(p_sig[p_sig > 0].min())-np.log(p_bkg))[p_sig == 0]
+        score[(p_bkg == 0) & (p_sig == 0)] = 0
+
+    return score
+
+
+class BackgroundID(H5FlowStage):
+    class_version = '0.0.0'
+
+    defaults = dict(
+        hits_dset_name='charge/hits',
+        charge_dset_name='charge/hits',
+        drift_dset_name='combined/hit_drift',
+        profile_dset_name='analysis/stopping_muons/event_profile',
+        stopping_sel_dset_name='analysis/stopping_muons/event_sel_reco',
+        hit_prof_dset_name='analysis/stopping_muons/hit_profile',
+
+        hit_label_dset_name='analysis/michel_id/hit_bkg_label',
+        bkg_label_dset_name='analysis/michel_id/bkg_label',
+
+        score_cut=0.0,
+        likelihood_pdf_filename='bkg_pdf-{version}.npz',
+        generate_likelihood_pdf=False,
+        update_likelihood=True
+        )
+
+    bkg_label_dtype = np.dtype([
+        ('bkg_nhit', 'i4'),
+        ('bkg_q', 'f4'),
+        ('muon_dir', 'f8', (3,)),
+        ('stop_pt', 'f8', (3,))
+    ])
+
+    hit_label_dtype = np.dtype([
+        ('score', 'f8'),
+        ('bkg_flag', 'u1'),
+        ('muon_flag', 'u1')
+    ])
+
+    likelihood_bins = (np.linspace(-1, 1, 50), np.geomspace(2, 1000, 50))
+
+    def __init__(self, **params):
+        super(BackgroundID, self).__init__(**params)
+        for name, default in self.defaults.items():
+            setattr(self, name, params.get(name, default))
+
+        self.likelihood_pdf_filename = self.likelihood_pdf_filename.format(version=self.class_version)
+
+    def init(self, source_name):
+        super(BackgroundID, self).init(source_name)
+
+        self.larpix_gain = self.data_manager.get_attrs('/'.join(self.stopping_sel_dset_name.split('/')[:-1]))['larpix_gain']
+        if self.rank == 0:
+            logging.warn(f'Using larpix gain of {self.larpix_gain:0.04f}')
+
+        # load likelihood function
+        if not self.generate_likelihood_pdf:
+            pdf = load_likelihood_pdf(self.likelihood_pdf_filename)
+            self.bkg_likelihood_args = pdf['sig'], pdf['bkg'], pdf['bins0'], pdf['bins1']
+        else:
+            sig = np.zeros([len(bins)-1 for bins in self.likelihood_bins])
+            bkg = np.zeros([len(bins)-1 for bins in self.likelihood_bins])
+            self.bkg_likelihood_args = [sig, bkg] + [bins for bins in self.likelihood_bins]
+
+        # save attributes
+        attrs = dict(classname=self.classname, class_version=self.class_version)
+        for name in self.defaults.keys():
+            attrs[name] = getattr(self, name)
+        self.data_manager.set_attrs(self.bkg_label_dset_name, **attrs)
+
+        # create datasets
+        self.data_manager.create_dset(self.bkg_label_dset_name, self.bkg_label_dtype)
+        self.data_manager.create_dset(self.hit_label_dset_name, self.hit_label_dtype)
+        self.data_manager.create_ref(self.hit_label_dset_name, self.hits_dset_name)
+
+    def finish(self, source_name):
+        if self.generate_likelihood_pdf:
+            # gather likelihood histograms from all threads
+            if H5FLOW_MPI:
+                self.bkg_likelihood_args[0] = np.array(self.comm.gather(self.bkg_likelihood_args[0], root=0))
+                self.bkg_likelihood_args[0] = np.sum(self.bkg_likelihood_args[0], axis=0)
+                self.bkg_likelihood_args[1] = np.array(self.comm.gather(self.bkg_likelihood_args[1], root=0))
+                self.bkg_likelihood_args[1] = np.sum(self.bkg_likelihood_args[1], axis=0)
+
+            # save to file
+            if self.rank == 0:
+                if self.update_likelihood and os.path.exists(self.likelihood_pdf_filename):
+                    d = np.load(self.likelihood_pdf_filename)
+                    assert np.all(d['bins0'] == self.bkg_likelihood_args[2])
+                    assert np.all(d['bins1'] == self.bkg_likelihood_args[3])
+                    self.bkg_likelihood_args[0] += d['sig']
+                    self.bkg_likelihood_args[1] += d['bkg']
+                    
+                np.savez_compressed(self.likelihood_pdf_filename,
+                                    sig=self.bkg_likelihood_args[0],
+                                    bkg=self.bkg_likelihood_args[1],
+                                    bins0=self.bkg_likelihood_args[2],
+                                    bins1=self.bkg_likelihood_args[3])
+
+    def run(self, source_name, source_slice, cache):
+        super(BackgroundID, self).run(source_name, source_slice, cache)
+        ev = cache[source_name]
+        hits = cache[self.hits_dset_name]
+
+        if len(ev):
+            # load hit xyz positions
+            hit_drift = cache[self.drift_dset_name].reshape(hits.shape)
+            hit_q = cache[self.charge_dset_name].reshape(hits.shape)['q']
+            hit_prof = cache[self.hit_prof_dset_name].reshape(hits.shape)
+            hit_prof.mask = hit_prof.mask['idx'] | (hit_prof['idx'] == -1) # ignore non-profiled hits
+            hit_prof_idx = hit_prof['idx']
+            hit_prof_rr = hit_prof['rr']
+            hit_xyz = np.concatenate([
+                np.expand_dims(hits['px'], -1), np.expand_dims(hits['py'], -1),
+                np.expand_dims(hit_drift['z'], -1)], axis=-1)
+
+            # load dQ/dx profile and stopping event selection
+            stopping_sel = self.data_manager[self.stopping_sel_dset_name, source_slice].reshape(ev.shape)
+            prof = self.data_manager[self.profile_dset_name, source_slice].reshape(ev.shape)
+            sel_mask = stopping_sel['sel'].astype(bool)
+
+            # find end points
+            #mu_end = stopping_sel['stop_pt'] + stopping_sel['stop_pt_corr']
+            hit_stop_d = np.linalg.norm(hit_xyz - (stopping_sel['stop_pt'] + stopping_sel['stop_pt_corr'])[...,np.newaxis,:], axis=-1)
+            mu_end = np.take_along_axis(
+                hit_xyz, np.expand_dims(np.argmax(hit_q * (hit_stop_d < 22), axis=-1), (1,2)), axis=1)
+            mu_end = mu_end.reshape(ev.shape + (3,))
+            no_near_hits_mask = ~((hit_stop_d < 22).any(axis=-1))
+            mu_end[no_near_hits_mask] = (stopping_sel['stop_pt'] + stopping_sel['stop_pt_corr'])[no_near_hits_mask]
+            #mu_end = np.take_along_axis(
+            #    hit_xyz, np.expand_dims(np.argmin(np.abs(hit_prof_rr), axis=-1), (1,2)), axis=1)
+            mu_end = mu_end.reshape(ev.shape + (3,))
+
+            # find axes
+            # use charge weighted average position for hits near end point
+            hit_dr = hit_xyz - mu_end[...,np.newaxis,:]
+            hit_d = np.linalg.norm(hit_dr, axis=-1)
+            muon_flag = (hit_prof_rr >= 0)
+            
+            muon_range_mask = np.broadcast_to(np.expand_dims(muon_flag & (hit_d < 200), axis=-1), hit_xyz.shape)            
+            mu_dir = ma.average(ma.array(hit_dr, mask=~muon_range_mask), weights=np.broadcast_to(hit_q[...,np.newaxis], hit_dr.shape), axis=1)
+            mu_dir /= np.clip(np.linalg.norm(mu_dir, axis=-1, keepdims=True), 1e-15, None)
+
+            # calculate likelihood parameters
+            hit_cos_mu = np.sum((hit_xyz - mu_end[:, np.newaxis, :])
+                                * mu_dir[:, np.newaxis, :], axis=-1)
+            hit_cos_mu /= np.clip(np.linalg.norm(hit_xyz - mu_end[:, np.newaxis, :], axis=-1), 1e-15, None)
+            hit_d = np.sqrt(np.sum((hit_xyz - mu_end[:, np.newaxis, :])**2, axis=-1))
+
+            # score hits
+            hit_score = bkg_likelihood_score(hit_cos_mu, hit_d, *self.bkg_likelihood_args)
+
+            if self.generate_likelihood_pdf and resources['RunData'].is_mc:
+                # FIXME: paths are hardcoded and loaded on each execution, might impact performance or break if datatypes change
+                event_truth = np.expand_dims(self.data_manager['analysis/muon_capture/truth_labels', source_slice], axis=-1)
+                hit_traj = self.data_manager[source_name, 'charge/hits', 'charge/raw_hits',
+                                             'charge/packets', 'mc_truth/tracks',
+                                             'mc_truth/trajectories', source_slice] # ev, hit, rawhit, packet, true track, traj
+                hit_frac = self.data_manager[source_name, 'charge/hits', 'charge/raw_hits',
+                                             'charge/packets',
+                                             'mc_truth/packet_fraction',
+                                             source_slice] # ev, hit, rawhit, packet, true track
+                hit_traj = np.take_along_axis(
+                    hit_traj, np.expand_dims(np.argmax(hit_frac, axis=-1), axis=(-2,-1)),
+                    axis=-2)
+                hit_traj = hit_traj[:,:,0].reshape(hits.shape)
+                hit_label_truth = (
+                    (hit_traj['trackID'] != event_truth['stopping_track_id'])
+                    # | (hit_traj['parentID'] == event_truth['michel_track_id']))
+                    & event_truth['michel'].astype(bool))
+
+                michel_mask = sel_mask # event mask
+                hist_mask = (~hit_label_truth.mask & ~muon_flag) # hit mask
+                sig, bkg = fill_likelihood_pdf(
+                    hit_cos_mu[sel_mask][hist_mask[sel_mask]],
+                    hit_d[sel_mask][hist_mask[sel_mask]],
+                    hit_label_truth[sel_mask][hist_mask[sel_mask]].astype(bool),
+                    *self.bkg_likelihood_args)
+                self.bkg_likelihood_args[0] = sig
+                self.bkg_likelihood_args[1] = bkg
+
+        # create output arrays
+        bkg_label = np.empty(ev.shape, dtype=self.bkg_label_dtype)
+        if len(ev):
+            bkg_label['bkg_nhit'] = np.sum((hit_score < self.score_cut) & ~muon_flag, axis=-1)
+            bkg_label['bkg_q'] = np.sum(hit_q * (hit_score < self.score_cut) * ~muon_flag, axis=-1)            
+            bkg_label['muon_dir'] = mu_dir
+            bkg_label['stop_pt'] = mu_end
+
+        hit_mask = ~hits['id'].mask
+        hit_label = np.empty(hit_mask.sum(), dtype=self.hit_label_dtype)
+        if np.any(hit_mask):
+            hit_label['score'] = hit_score[hit_mask]
+            hit_label['bkg_flag'] = ((hit_score < self.score_cut) & ~muon_flag)[hit_mask]
+            hit_label['muon_flag'] = muon_flag[hit_mask]
+
+        # write to file
+        self.data_manager.reserve_data(self.bkg_label_dset_name, source_slice)
+        self.data_manager.write_data(self.bkg_label_dset_name, source_slice, bkg_label)
+
+        hit_label_slice = self.data_manager.reserve_data(self.hit_label_dset_name, int(hit_mask.sum()))
+        self.data_manager.write_data(self.hit_label_dset_name, hit_label_slice, hit_label)
+        self.data_manager.write_ref(self.hit_label_dset_name, self.hits_dset_name,
+                                    np.c_[hit_label_slice, hits['id'].compressed()])

--- a/src/module0_flow/analysis/dropout.py
+++ b/src/module0_flow/analysis/dropout.py
@@ -1,0 +1,79 @@
+import numpy as np
+import numpy.ma as ma
+import logging
+import scipy.stats as stats
+
+from h5flow.core import H5FlowStage, resources
+
+
+class Dropout(H5FlowStage):
+    '''
+    Masks the specified cached hits with a given uniform (aka Bernoulli) probability for downstream components.
+
+    Only runs on simulation.
+
+    Requires ``RunData`` resource.
+
+    Example config::
+
+      dropout:
+        classname: Dropout
+        path: module0_flow.analysis.dropout
+        requires:
+          - 'charge/hits' # should mimic description used by downstream stages
+        params:
+          mask: # multiple datasets can be masked as long as they are broadcastable, the first dataset is used to determine the baseline shape and generate the drop out mask
+            - 'charge/hits'
+          p: 0.03 # probability of dropping an item
+
+    '''
+    class_version = '0.0.0'
+    defaults = dict(p=0.05)
+
+    def __init__(self, **params):
+        super(Dropout, self).__init__(**params)
+        self.is_mc = False
+        for key in self.defaults:
+            setattr(self, key, params.get(key, self.defaults[key]))
+        self.mask = params['mask']
+
+    def init(self, source_name):
+        super(Dropout, self).init(source_name)
+        self.is_mc = resources['RunData'].is_mc
+        if not self.is_mc:
+            return
+
+    def run(self, source_name, source_slice, cache):
+        super(Dropout, self).run(source_name, source_slice, cache)
+        if not self.is_mc:
+            return
+
+        # fetch datasets from file
+        dsets = []
+        for name in self.mask:
+            dsets.append(cache[name])
+
+        # extract number of valid entries
+        n_unmasked = dsets[0].size
+        if hasattr(dsets[0], 'recordmask'):
+            n_unmasked = (~(dsets[0].recordmask)).sum()
+
+        # generate random mask
+        rvs = stats.bernoulli.rvs(p=1-self.p, size=n_unmasked).astype(bool)
+
+        # create a new mask using random mask
+        if hasattr(dsets[0], 'recordmask'):
+            new_mask = dsets[0].recordmask.copy()
+        else:
+            new_mask = np.zeros(dsets[0].shape, dtype=bool)
+        if n_unmasked > 0:
+            np.place(new_mask, ~new_mask, rvs)
+
+        # update cache with new masked arrays
+        for i, name in enumerate(self.mask):
+            new_mask_i = new_mask.copy()
+            while len(new_mask_i.shape) < len(cache[name].shape):
+                new_mask_i = np.expand_dims(new_mask_i, axis=-1)
+            new_mask_i = np.broadcast_to(new_mask_i, cache[name].shape)
+            logging.debug(f'dropped {(~(new_mask_i)).sum()} / {new_mask_i.shape} of {name}')
+            cache[name] = ma.array(cache[name], mask=new_mask_i.copy())

--- a/src/module0_flow/analysis/light_intensity_map.py
+++ b/src/module0_flow/analysis/light_intensity_map.py
@@ -157,6 +157,7 @@ class LightIntensityMapGenerator(H5FlowStage):
         xyz = np.c_[x,y,z]
 
         # apply gain calibration
+        gain = (221 if not resources['RunData'].is_mc else 222)
         q = hit_charge['q'].compressed() * gain # mV -> e
         q = np.where(resources['Geometry'].in_fid(xyz) & (hit_drift['t_drift'].compressed() < 1900) & (hit_drift['t_drift'].compressed() > 0), q, 0)
 

--- a/src/module0_flow/analysis/light_intensity_map.py
+++ b/src/module0_flow/analysis/light_intensity_map.py
@@ -11,33 +11,66 @@ from module0_flow.util import units
 class LightIntensityMapGenerator(H5FlowStage):
     '''
     Generates a 3D histogram of tracks not crossing the light detectors along with a 3+1D histogram of the light signal.
+
+    Uses the LArData resource
     '''
     x_bins = np.linspace(-310.38,310.38,15)
     y_bins = np.linspace(-620.76,620.76,27)
     z_bins = np.linspace(-304.31,304.31,17)
     d_bins = np.arange(33)
 
-    edge_cut = 20
+    edge_cut = 20 # avoid tracks that come within edge_cut mm of light detectors
 
     sum_files = True
+    charge_weighting = False
+    use_adc_channel_id = False
+
+    wvfm_dset_name = 'light/swvfm' # must have a samples field
+    tracks_dset_name = 'combined/tracks'
 
     q_file = 'light_intensity_q.sim.lut.v2.npz'
     s_file = 'light_intensity_s.sim.lut.v2.npz'
 
     def __init__(self, **params):
         super().__init__(**params)
+
+        self.q_file = params.get('q_file', self.q_file)
+        self.s_file = params.get('s_file', self.s_file)
+
+        self.sum_files = params.get('sum_files', self.sum_files)
+        self.charge_weighting = params.get('charge_weighting', self.charge_weighting)
+        self.use_adc_channel_id = params.get('use_adc_channel_id', self.use_adc_channel_id)
+
+        self.wvfm_dset_name = params.get('wvfm_dset_name', self.wvfm_dset_name)
+        self.charge_dset_name = params.get('charge_dset_name', self.charge_dset_name)
+        self.tracks_dset_name = params.get('tracks_dset_name', self.tracks_dset_name)
+        
+        self.q_bins = []
+        self.q_hist = None
+        
+        self.s_bins = []
+        self.s_hist = None
+
+        self.nevents = 0
+
+
+    def init(self, source_name):
+        ntpc, ndet, _ = self.data_manager.get_dset(self.wvfm_dset_name).dtype['samples'].shape
+        self.d_bins = np.arange(ntpc * ndet + 1)
+
+        self.q_bins = self.x_bins, self.y_bins, self.z_bins
+        self.s_bins = self.x_bins, self.y_bins, self.z_bins, self.d_bins
+
         if self.rank == 0:
             print('x_bins', self.x_bins.shape)
             print('y_bins', self.y_bins.shape)
             print('z_bins', self.z_bins.shape)
             print('d_bins', self.d_bins.shape)        
-        
-        self.q_bins = self.x_bins, self.y_bins, self.z_bins
+
         self.q_hist = self.fill_hist(None, np.zeros(1),np.zeros(1),np.zeros(1), weights=np.zeros(1), bins=self.q_bins)
-        
-        self.s_bins = self.x_bins, self.y_bins, self.z_bins, self.d_bins
         self.s_hist = self.fill_hist(None, np.zeros(1),np.zeros(1),np.zeros(1),np.zeros(1), weights=np.zeros(1), bins=self.s_bins)
 
+        
     @staticmethod
     def fill_hist(hist, x, y, z, d=None, weights=None, bins=None):
         '''
@@ -81,21 +114,24 @@ class LightIntensityMapGenerator(H5FlowStage):
             self.comm.Reduce(np.ascontiguousarray(self.q_hist), q_hist, root=0)
             s_hist = np.ascontiguousarray(np.zeros_like(self.s_hist))
             self.comm.Reduce(np.ascontiguousarray(self.s_hist), s_hist, root=0)
+            self.nevents = self.comm.reduce(self.nevents, root=0)
         else:
             q_hist = self.q_hist
             s_hist = self.s_hist
             
         # save to file
         if self.rank == 0:
-            print(q_hist.sum())
+            print(f'current events: {self.nevents}')
             if os.path.exists(self.q_file) and self.sum_files == True:
                 print('Loading existing data from file...')
                 q_hist += np.load(self.q_file)['hist']
             if os.path.exists(self.s_file) and self.sum_files == True:
                 s_hist += np.load(self.s_file)['hist']
-            print(q_hist.sum())
-            np.savez_compressed(self.q_file, hist=q_hist, bins=self.q_bins)
-            np.savez_compressed(self.s_file, hist=s_hist, bins=self.s_bins)
+                self.nevents += np.load(self.s_file)['nevents']
+
+            print(f'total events: {self.nevents}')
+            np.savez_compressed(self.q_file, hist=q_hist, bins=self.q_bins, nevents=self.nevents)
+            np.savez_compressed(self.s_file, hist=s_hist, bins=self.s_bins, nevents=self.nevents)
 
     def run(self, source_name, source_slice, cache):
         super().run(source_name, source_slice, cache)
@@ -103,41 +139,96 @@ class LightIntensityMapGenerator(H5FlowStage):
         n_ev = cache[source_name].shape[0]
         
         # get charge hits for event
+        events = cache['charge/events']
         hits = cache['charge/hits']
+        hit_charge = cache[self.charge_dset_name].reshape(hits.shape)
         hit_drift = cache['combined/hit_drift'].reshape(hits.shape)
+        t0 = cache['combined/t0']
+
+        # ensure good T0
+        if np.any(t0['type'] != 1):
+            return
+        if np.any(events['n_ext_trigs'] != 2):
+            return
 
         x = hits['px'].compressed()
         y = hits['py'].compressed()
         z = hit_drift['z'].compressed()
         xyz = np.c_[x,y,z]
-        q = hits['q'].compressed() * 221 # mV -> e
 
-        # avoid activity near field cage walls (except top and bottom)
-        if np.any((~resources['Geometry'].in_fid(xyz, field_cage_fid=self.edge_cut)) & ((y < 595) & (y > -595))):
+        # apply gain calibration
+        q = hit_charge['q'].compressed() * gain # mV -> e
+        q = np.where(resources['Geometry'].in_fid(xyz) & (hit_drift['t_drift'].compressed() < 1900) & (hit_drift['t_drift'].compressed() > 0), q, 0)
+
+        # get tracks for events
+        tracks = cache[self.tracks_dset_name]
+
+        # require at least 1 decent track length in the event
+        if not np.any(tracks['length'] > 100):
             return
-        if q.sum() < 1e6 or q.sum() > 2e7: # ~10cm -> 200cm MIP energy
+        # check the dQ/dx
+        avg_dqdx = np.mean(gain * tracks['dq'] / np.sqrt(np.sum(tracks['dx']**2, axis=-1)).clip(4, None), axis=-1)
+        if np.any((avg_dqdx > 8e3) | (avg_dqdx < 4e3)):
+            return
+        # check for bad track angle
+        if np.all(np.abs(np.diff(tracks['trajectory'], axis=-1)) < 20):
+            return
+        # avoid activity near field cage walls (except top and bottom)
+        if np.any((~resources['Geometry'].in_fid(xyz, field_cage_fid=self.edge_cut)) & ((y < 595) & (y > -595)) & resources['Geometry'].in_fid(xyz)):
+            return
+        # ~10cm -> 200cm MIP energy
+        if q.sum() < 1e6 or q.sum() > 2e7:
             return
         
         # get light detector signal
-        if np.all(cache['light/swvfm'].mask['samples']):
+        if cache[self.wvfm_dset_name] is None or np.all(cache[self.wvfm_dset_name].mask['samples']):
             return
-        light_signal = cache['light/swvfm'].reshape((n_ev, -1,))['samples'].filled(0.).sum(axis=-1).sum(axis=1)
-        tpc_id, det_id = np.indices(light_signal.shape)[-2:]
-        
-        # calculate solid angle weight
-        omega = resources['Geometry'].solid_angle(
-            np.c_[hits['px'].compressed(), hits['py'].compressed(), hit_drift['z'].compressed()],
-            tpc_id, det_id)
-        omega = omega.reshape(-1, np.prod(light_signal.shape[-2:]))
-        light_signal = light_signal.reshape(-1, omega.shape[-1])
-        det_id = det_id.reshape(light_signal.shape)
-        tpc_id = tpc_id.reshape(light_signal.shape)        
 
-        norm = (omega * q[:, np.newaxis]).sum(axis=0, keepdims=True)
-        q_weight = ((q[:,np.newaxis] * omega) / np.clip(norm, 1e-15, None))
+        light_signal = cache[self.wvfm_dset_name].reshape((n_ev, -1,))['samples'].filled(0.).astype(float).sum(axis=-1).sum(axis=1)
+        ntpc = light_signal.shape[-2]
+        ndet = light_signal.shape[-1]
+        tpc_id, det_id = np.indices(light_signal.shape)[-2:]
+
+        light_signal = light_signal.reshape(-1, ntpc*ndet)
+        tpc_id = tpc_id.reshape(-1, ntpc*ndet)
+        det_id = det_id.reshape(-1, ntpc*ndet)
+
+        # set output index in resulting histogram
+        s_hist_index = det_id + tpc_id * ndet
+
+        # calculate solid angle weight
+        if self.use_adc_channel_id == True:
+            # reinterprets waveform shape as (adc index, detector index)
+            adc_id = tpc_id.copy()
+            channel_id = det_id.copy()
+
+            tpc_id = resources['Geometry'].tpc_id[(adc_id.ravel(), channel_id.ravel())]
+            det_id = resources['Geometry'].det_id[(adc_id.ravel(), channel_id.ravel())]
+
+            tpc_id = tpc_id.reshape(adc_id.shape)
+            det_id = det_id.reshape(channel_id.shape)
+
+        omega = resources['Geometry'].solid_angle(xyz, tpc_id, det_id)
+        omega = omega.reshape(xyz.shape[0:1] + light_signal.shape[1:])
+        # enforce cathode non-visibility
+        omega[(xyz[:,2][:,np.newaxis] < 0) & (tpc_id != 0)] = 0
+        omega[(xyz[:,2][:,np.newaxis] > 0) & (tpc_id != 1)] = 0
+        # insure that any invalid hits are not counted in sum
+        omega[~resources['Geometry'].in_fid(xyz)] = 0
+        omega[((xyz[:,0] == xyz[:,1]) & (xyz[:,1] == 0)).ravel()] = 0
+        q[((xyz[:,0] == xyz[:,1]) & (xyz[:,1] == 0)).ravel()] = 0
+
+        if self.charge_weighting == False:
+            norm = omega.sum(axis=0, keepdims=True)
+            q_weight = omega / np.clip(norm, 1e-15, None)
+        else:
+            norm = (omega * q[:, np.newaxis]).sum(axis=0, keepdims=True)
+            q_weight = ((q[:,np.newaxis] * omega) / np.clip(norm, 1e-15, None))
         q_weight[:,(norm < 1e-15).ravel()] = 0
         
         # update histograms
         self.q_hist = self.fill_hist(self.q_hist, x, y, z, weights=q, bins=self.q_bins)
-        self.s_hist = self.fill_hist(self.s_hist, x[:,np.newaxis], y[:,np.newaxis], z[:,np.newaxis], det_id + tpc_id * 16, weights=light_signal * q_weight, bins=self.s_bins)
-        
+        self.s_hist = self.fill_hist(self.s_hist, x[:,np.newaxis], y[:,np.newaxis], z[:,np.newaxis], s_hist_index, weights=light_signal * q_weight, bins=self.s_bins)
+
+        self.nevents += 1
+

--- a/src/module0_flow/reco/charge/raw_event_generator.py
+++ b/src/module0_flow/reco/charge/raw_event_generator.py
@@ -353,7 +353,7 @@ class RawEventGenerator(H5FlowGenerator):
 
         logging.info(f'total packets: {len(block)}')
         logging.info(f'valid entries: {mask.sum()}')
-        logging.info(f'bad parity: {block["valid_parity"].astype(bool).sum()}')
+        logging.info(f'valid parity: {block["valid_parity"].astype(bool).sum()}')
         logging.info(f'messages: {(block["packet_type"] == 4).sum()}')
         logging.info(f'triggers: {(block["packet_type"] == 7).sum()}')
         logging.info(f'syncs: {(block["packet_type"] == 6).sum()}')        

--- a/src/module0_flow/reco/charge/raw_event_generator.py
+++ b/src/module0_flow/reco/charge/raw_event_generator.py
@@ -126,10 +126,13 @@ class RawEventGenerator(H5FlowGenerator):
         self.event_builder = globals()[self.event_builder_class](**self.event_builder_config)
 
         # set up input file
-        if H5FLOW_MPI:
-            self.input_fh = h5py.File(self.input_filename, 'r', driver='mpio', comm=self.comm)
+        if self.input_filename == self.data_manager.filepath:
+            self.input_fh = self.data_manager
         else:
-            self.input_fh = h5py.File(self.input_filename, 'r')
+            if H5FLOW_MPI:
+                self.input_fh = h5py.File(self.input_filename, 'r', driver='mpio', comm=self.comm)
+            else:
+                self.input_fh = h5py.File(self.input_filename, 'r')
         self.packets = self.input_fh['packets']
 
         # set up loop variables

--- a/src/module0_flow/reco/combined/electron_lifetime.py
+++ b/src/module0_flow/reco/combined/electron_lifetime.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.ma as ma
+import os
 import scipy.optimize as optimize
 import scipy.stats as stats
 import scipy.interpolate as interpolate
@@ -8,6 +9,8 @@ import scipy.signal as signal
 
 from h5flow import H5FLOW_MPI
 from h5flow.core import H5FlowStage, resources
+
+from module0_flow.util.func import condense_array
 
 
 class ElectronLifetimeCalib(H5FlowStage):
@@ -27,6 +30,8 @@ class ElectronLifetimeCalib(H5FlowStage):
          - ``mode``: ``str``, one of "generate" or "calibration"
          - ``electron_lifetime_file``: ``str``, path to .npz file to update with new electron lifetime values (only applies to "generate" mode), will name with the measured unix timestamp
          - ``tracks_dset_name``: ``str``, path to input tracks dataset (only applies to generate mode)
+         - ``true_segments_dset_name``: ``str``, path to input true segments dataset for each hit (only applies to generate mode for simulation)
+         - ``update_result``: ``bool``, flag to add to existing calibration file, otherwise will create a new file based on the timestamp (only applies to generate mode)
          - ``calib_dset_name``: ``str``, path to output dataset (only applies to "calibration" mode)
 
         Important note!! ``hits_dset_name`` and ``drift_dset_name`` do double duty and have different requirements depending on the run mode: in ``"generate"`` mode these represent the hits and drift info for the hits associated with each track, whereas in ``"calibration"`` mode these are the hits and drift info for the event. So the nominal corresponding requirements field should be::
@@ -56,10 +61,13 @@ class ElectronLifetimeCalib(H5FlowStage):
 
         The output electron lifetime file is a .npz collection containing:
 
+         - ``ntracks``:         number of tracks used in fit
          - ``drift_bins``:      1D array of drift time bin edges
          - ``dqdx_bins``:       1D array of dQ/dx bin edges
+         - ``dedx_bins``:       1D array of dE/dx bin edges (simulation only)
          - ``timestamp``:       averaged unix time across run [s]
          - ``hist``:            2D array of bin counts for track dQ/dx
+         - ``dedx_hist``:       2D array of bin counts for track true dE/dx (simulation only)
          - ``lifetime``:        best fit electron lifetime
          - ``lifetime_err``:    best fit electron lifetime error
          - ``dqdx0``:           best fit dQ/dx(t=0)
@@ -88,10 +96,14 @@ class ElectronLifetimeCalib(H5FlowStage):
     default_drift_dset_name = 'combined/hit_drift'
     default_calib_dset_name = 'combined/q_calib'
     default_tracks_dset_name = 'combined/tracklets'
+    default_true_segments_dset_name = 'mc_truth/hits/tracks'
 
-    default_drift_bins = np.linspace(0,188,16) # us
-    default_dqdx_bins = np.linspace(0,90,101) # mV/mm
+    default_drift_bins = np.linspace(0, 188, 16) # us
+    default_dqdx_bins = np.linspace(0, 90, 101) # mV/mm
+    default_dedx_bins = np.linspace(0, 600, 101) # keV/mm
+    default_dndx_bins = np.linspace(0, 1, 101) # 1/mm
 
+    default_update_result = True
     
     def __init__(self, **params):
         super(ElectronLifetimeCalib, self).__init__(**params)
@@ -101,6 +113,7 @@ class ElectronLifetimeCalib(H5FlowStage):
         self.charge_dset_name = params.get('charge_dset_name', self.default_charge_dset_name)
         self.tracks_dset_name = params.get('tracks_dset_name', self.default_tracks_dset_name)
         self.calib_dset_name = params.get('calib_dset_name', self.default_calib_dset_name)
+        self.true_segments_dset_name = params.get('true_segments_dset_name', self.default_true_segments_dset_name)
 
         # declare run mode
         self.mode = params['mode']
@@ -112,14 +125,23 @@ class ElectronLifetimeCalib(H5FlowStage):
             raise RuntimeError(f'{self.mode} not a valid run mode')
 
         self.electron_lifetime_file = params['electron_lifetime_file'] if self.mode == self.GENERATE else None
+        self.update_result = params.get('update_result', self.default_update_result)
         self.drift_bins = np.array(params.get('drift_bins', self.default_drift_bins))
         self.dqdx_bins = np.array(params.get('dqdx_bins', self.default_dqdx_bins))
+        self.dedx_bins = np.array(params.get('dedx_bins', self.default_dedx_bins))
+        self.dndx_bins = np.array(params.get('dndx_bins', self.default_dndx_bins))
+        self.angle_bins = np.linspace(-np.pi/2, np.pi/2, 101)
 
         self.dqdx_hist = np.zeros((self.drift_bins.shape[0]-1, self.dqdx_bins.shape[0]-1)) if self.mode == self.GENERATE else None
+        self.dedx_hist = np.zeros((self.drift_bins.shape[0]-1, self.dedx_bins.shape[0]-1)) if self.mode == self.GENERATE else None
+        self.dndx_hist = np.zeros((self.drift_bins.shape[0]-1, self.dndx_bins.shape[0]-1)) if self.mode == self.GENERATE else None
+        self.zen_hist = np.zeros((self.drift_bins.shape[0]-1, self.angle_bins.shape[0]-1)) if self.mode == self.GENERATE else None
+        self.anode_hist = np.zeros((self.drift_bins.shape[0]-1, self.angle_bins.shape[0]-1)) if self.mode == self.GENERATE else None        
 
         self.timestamp = None
         self.timestamp_n = 0
 
+        self.ntracks = 0
 
     def init(self, source_name):
         super(ElectronLifetimeCalib, self).init(source_name)
@@ -170,9 +192,22 @@ class ElectronLifetimeCalib(H5FlowStage):
         return sum([args[i] * (dqdx)**i for i in range(len(args))])
 
     @staticmethod
+    def langau(dqdx, norm, mpv, eta, sigma, A):
+        import pylandau
+        return norm * pylandau.langau(dqdx, mpv, eta, sigma, np.abs(A))
+
+    @staticmethod
     def f_decay(t, max_, tau, power, power_scale):
         ''' Power-law modified exponential to account for electron lifetime and signal truncation close to anode '''
-        return max_ * np.exp(-t/tau) * (1 - 1 / (1 + np.power(np.abs(t/power_scale), power)))
+        v = np.power(np.abs(t / power_scale), power)
+        v = 1 / (v + 1)
+        # enforce truncation constrained to 0 -> 1
+        rescale_offset = v.min()
+        rescale_norm = 1 - rescale_offset
+        v -= rescale_offset
+        v /= rescale_norm
+        v[t <= 0] = 1
+        return max_ * np.exp(-t/tau) * (1 - v)
 
     def finish(self, source_name):
         if self.mode == self.GENERATE:
@@ -180,7 +215,30 @@ class ElectronLifetimeCalib(H5FlowStage):
                 hists = self.comm.gather(self.dqdx_hist)
                 self.dqdx_hist = np.sum(hists, axis=0)
 
+                hists = self.comm.gather(self.dedx_hist)
+                self.dedx_hist = np.sum(hists, axis=0)
+
+                hists = self.comm.gather(self.dndx_hist)
+                self.dndx_hist = np.sum(hists, axis=0)                
+
+                hists = self.comm.gather(self.zen_hist)
+                self.zen_hist = np.sum(hists, axis=0)
+
+                hists = self.comm.gather(self.anode_hist)
+                self.anode_hist = np.sum(hists, axis=0)                
+
+                ntracks = self.comm.gather(self.ntracks)
+                self.ntracks = np.sum(ntracks)
+
             if self.rank == 0:
+                if self.update_result == True and os.path.exists(self.electron_lifetime_file):
+                    self.dqdx_hist = np.load(self.electron_lifetime_file)['hist'] + self.dqdx_hist
+                    self.dedx_hist = np.load(self.electron_lifetime_file)['dedx_hist'] + self.dedx_hist
+                    self.dndx_hist = np.load(self.electron_lifetime_file)['dndx_hist'] + self.dndx_hist                    
+                    self.zen_hist = np.load(self.electron_lifetime_file)['zen_hist'] + self.zen_hist
+                    self.anode_hist = np.load(self.electron_lifetime_file)['anode_hist'] + self.anode_hist                    
+                    old_ntracks = np.load(self.electron_lifetime_file)['ntracks']
+                
                 # set up fits
                 n_poly_terms = 5
                 bootstrap_count = 30
@@ -193,38 +251,44 @@ class ElectronLifetimeCalib(H5FlowStage):
                 for ibin in range(len(self.drift_bins)-1):
                     print(f'drift time: {self.drift_bins[1:][ibin]:0.02f}us')
                     mask = self.dqdx_hist[ibin] > 0
-                    if np.sum(mask) < 4:
+                    #if np.sum(mask) < 4:
+                    if np.sum(self.dqdx_hist[ibin]) < 5000:
                         print(f'\t*** {ibin} not enough non-zero bins to fit ***')
-                        continue                    
+                        continue
 
                     # scale factor to increase errors on each bootstrap fit in order to account for any systematic biases in fit
                     systematic_factor = 1
 
-                    # use +/- 1 sigma region around each peak for polynomial fit
-                    max_ = self.weighted_percentile(dqdx_bin_center, self.dqdx_hist[ibin], 0.84)
-                    min_ = self.weighted_percentile(dqdx_bin_center, self.dqdx_hist[ibin], 0.16)
-                    fit_mask = mask & (dqdx_bin_center >= min_) & (dqdx_bin_center <= max_)
-
                     # calculate bootstrap errors
                     for ibstrp in range(bootstrap_count):
-                        # apply boostrap statistical fluctuations assuming bins random normally distributed
                         # also includes the adaptive systematic factor
-                        dqdx_hist = self.dqdx_hist[ibin] + np.random.normal(size=self.dqdx_hist[ibin].shape, loc=0, scale=np.sqrt(self.dqdx_hist[ibin].clip(1,None))) * fit_mask * systematic_factor
+                        dqdx_hist = (self.dqdx_hist[ibin] + np.random.normal(size=self.dqdx_hist[ibin].shape, loc=0, scale=systematic_factor * np.sqrt(self.dqdx_hist[ibin].clip(1,None)))).clip(0, None) 
                         try:
+                            # apply boostrap statistical fluctuations assuming bins random normally distributed
+                            # use +/- 1 sigma region around each peak for polynomial fit
+                            #max_ = self.weighted_percentile(dqdx_bin_center, dqdx_hist, 0.84)
+                            #min_ = self.weighted_percentile(dqdx_bin_center, dqdx_hist, 0.16)
+                            min_ = self.weighted_percentile(dqdx_bin_center, dqdx_hist, 0.05)
+                            max_ = 2 * self.weighted_percentile(dqdx_bin_center, dqdx_hist, 0.5) - min_
+                            #max_ = dqdx_bin_center.max()
+                            #min_ = dqdx_bin_center.min()
+                            fit_mask = mask & (dqdx_bin_center >= min_) & (dqdx_bin_center <= max_) & (dqdx_hist > 0)
+                            
                             # perform the polynomial fit to the peak
-                            p0 = (dqdx_hist[fit_mask].mean(),) + (0,) * (n_poly_terms - 1)
-                            err = np.sqrt(dqdx_hist[fit_mask]) * systematic_factor
-                            fit_func = self.f_poly
+                            #fit_func = self.f_poly                            
+                            #p0 = (dqdx_hist[fit_mask].mean(),) + (0,) * (n_poly_terms - 1)
+                            fit_func = self.langau
+                            p0 = (dqdx_hist.sum()/7.5, self.weighted_percentile(dqdx_bin_center, dqdx_hist, 0.5)/1.05, 1, 1.8, 0.5)
+                            err = systematic_factor * np.sqrt(dqdx_hist[fit_mask]).clip(1,None)
                             p, cov = optimize.curve_fit(fit_func, dqdx_bin_center[fit_mask],
                                                         dqdx_hist[fit_mask],
-                                                        p0=p0, sigma=err)
+                                                        p0=p0, sigma=err, bounds=([0, 0, 0, 0, 0], [np.inf, 100, 10, 10, 10]))
 
                             chi2 = ((dqdx_hist[fit_mask] - fit_func(dqdx_bin_center[fit_mask], *p))**2 / err**2).sum()
                             ndf = fit_mask.sum() - len(p)
-                            print(f'\t{ibstrp} chi2/ndf = {chi2:0.02f}/{ndf:d} ({chi2/ndf:0.04f}) [f={systematic_factor:0.2f}]')
 
                             # update the systematic factor using rolling average
-                            systematic_factor = (0.75 * systematic_factor + 0.25 * chi2 / ndf)
+                            systematic_factor = (bootstrap_count-1)/bootstrap_count * systematic_factor + 1/bootstrap_count * chi2 / ndf * systematic_factor
                             #for iparam,param in enumerate(p):
                             #    print(f'\t  {iparam}: {param:0.03f}')
 
@@ -233,29 +297,69 @@ class ElectronLifetimeCalib(H5FlowStage):
                             extrema = spline.derivative(1).roots(extrapolate=False)
                             maximum = extrema[np.argmax(spline(extrema))]
 
-                            dqdx_p[ibin,ibstrp] = maximum
+                            #dqdx_p[ibin,ibstrp] = maximum
+                            dqdx_p[ibin,ibstrp] = p[1]
                             dqdx_p_valid[ibin,ibstrp] = True
+
+                            print(f'\t{ibstrp} chi2/ndf = {chi2:0.02f}/{ndf:d} ({chi2/ndf:0.04f}) [f={systematic_factor:0.2f}], '
+                                  f'peak = {dqdx_p[ibin,ibstrp]:0.04f} mV/mm')
+                            #print(p0)
+                            #print(p)
+
+                            if ibstrp in (bootstrap_count-1, 0) and False:
+                                import matplotlib.pyplot as plt
+                                plt.figure()
+                                plt.errorbar(dqdx_bin_center[fit_mask], dqdx_hist[fit_mask], yerr=err, color='k', fmt='.')
+                                plt.plot(dqdx_bin_center[fit_mask], fit_func(dqdx_bin_center[fit_mask], *p0), label='init', color='r', ls='--')                                
+                                plt.plot(dqdx_bin_center[fit_mask], spline(dqdx_bin_center[fit_mask]), label='fit', color='r')
+                                plt.axvline(maximum, color='r', ls=':', label='peak')
+                                plt.legend()
+                                plt.xlabel('dQ/dx [mV/mm]')
+                                plt.show()
                                 
                         except Exception as e:
-                            print('\t{ibstrp} ERROR:', e)
+                            print(f'\t{ibstrp} ERROR:', e)
 
                     print(f'\tpeak: {dqdx_p[ibin].mean():0.03f} +/- {dqdx_p[ibin].std():0.03f} mV/mm')
 
+                print('Final result')
+                result = dict(
+                    drift_bins=self.drift_bins,
+                    dqdx_bins=self.dqdx_bins,
+                    dedx_bins=self.dedx_bins,
+                    dndx_bins=self.dndx_bins,
+                    angle_bins=self.angle_bins,
+                    timestamp=self.timestamp,
+                    hist=self.dqdx_hist,
+                    dedx_hist=self.dedx_hist,
+                    dndx_hist=self.dndx_hist,
+                    zen_hist=self.zen_hist,
+                    anode_hist=self.anode_hist,
+                    dqdx_p=dqdx_p,
+                    dqdx_p_valid=dqdx_p_valid,
+                )
+                    
+                print(f'total selected tracks = {self.ntracks}')
+                if self.update_result == True and os.path.exists(self.electron_lifetime_file):
+                    print(f'previous tracks = {old_ntracks}')
+                    self.ntracks += old_ntracks
+                result['ntracks'] = self.ntracks
+
                 # fit the electron lifetime
                 try:
-                    print('Final result')
                     # skip the last drift time bin to avoid dQ/dx for portion of track that crosses cathode
-                    subset = slice(0,-1)
+                    subset = slice(1,-1)
 
                     # create fit data
-                    peak_fit = dqdx_p.mean(axis=-1) * (dqdx_p_valid.sum(axis=-1) > 1)
-                    peak_err = dqdx_p.std(axis=-1) * (dqdx_p_valid.sum(axis=-1) > 3)
+                    peak_fit = ma.array(dqdx_p, mask=~(dqdx_p_valid.astype(bool))).mean(axis=-1)
+                    peak_err = ma.array(dqdx_p, mask=~(dqdx_p_valid.astype(bool))).std(axis=-1)                                        
                     # if polynomial fit was bad, apply huge error bars
+                    peak_err = peak_err.filled(peak_fit.max())
                     peak_err[peak_err == 0] = peak_fit.max()
 
                     # do drift time response fit
                     lt_pnames = ('dQ/dx(0) [mV/mm]','lifetime [us]','decay power','decay scale [us]')
-                    p0 = (peak_fit[1], 2e3, 2, 2)
+                    p0 = (peak_fit[1], 3e3, 2, 2)
                     p, cov = optimize.curve_fit(self.f_decay, drift_bin_center[subset],
                                                 peak_fit[subset],
                                                 p0=p0, sigma=peak_err[subset],
@@ -271,23 +375,21 @@ class ElectronLifetimeCalib(H5FlowStage):
                     for iparam,p_name in enumerate(lt_pnames):
                         print(f'{p_name}: {p[iparam]:0.03f} +/- {perr[iparam]}')
 
-                    # save results to an output file
-                    np.savez_compressed(self.electron_lifetime_file[:-3]+f'{int(self.timestamp)}.npz',
-                                        drift_bins=self.drift_bins,
-                                        dqdx_bins=self.dqdx_bins,
-                                        timestamp=self.timestamp,
-                                        hist=self.dqdx_hist,
-                                        lifetime=p[1],
-                                        lifetime_err=perr[1],
-                                        dqdx0=p[0],
-                                        dqdx0_err=perr[0],
-                                        other_fit_p=p[2:],
-                                        other_fit_p_err=perr[2:],
-                                        dqdx_p=dqdx_p,
-                                        dqdx_p_valid=dqdx_p_valid,
-                        )
+                    result['lifetime'] = p[1]
+                    result['lifetime_err'] = perr[1]
+                    result['dqdx0'] = p[0]
+                    result['dqdx0_err'] = perr[0]
+                    result['other_fit_p'] = p[2:]
+                    result['other_fit_p_err'] = perr[2:]
                 except Exception as e:
                     print(f'ERROR: {e}')
+                finally:
+                    # save results to an output file
+                    output_filename = (self.electron_lifetime_file[:-3]+f'{int(self.timestamp)}.npz'
+                                       if self.update_result == False
+                                       else self.electron_lifetime_file)
+                    np.savez_compressed(output_filename, **result)
+                    
 
     def run(self, source_name, source_slice, cache):
         super(ElectronLifetimeCalib, self).run(source_name, source_slice, cache)
@@ -349,10 +451,14 @@ class ElectronLifetimeCalib(H5FlowStage):
             
             # grab tracks from file
             tracks = cache[self.tracks_dset_name]
-
+            
             # apply track quality selection
+            theta_anode = np.arctan2(tracks['start'][...,2] - tracks['end'][...,2], np.linalg.norm(tracks['start'][...,:2] - tracks['end'][...,:2], axis=-1))
+            theta_zen = np.arctan2(np.linalg.norm(tracks['start'][...,[0,2]] - tracks['end'][...,[0,2]], axis=-1), tracks['start'][...,1] - tracks['end'][...,1])
             track_mask = tracks['length'] > 100 # mm, >10cm tracks
             track_mask = track_mask & (events['n_ext_trigs'] == 2)[:,np.newaxis] # only one light trigger
+            track_mask = track_mask & (tracks['start'][...,2] * tracks['end'][...,2] > 0) # only one active TPC
+            track_mask = track_mask & (theta_zen < 0.3) & (theta_anode < 0.3) # subselect angle to reduce bias
 
             # apply hit quality selection
             xyz = np.c_[hits['px'].ravel(), hits['py'].ravel(), drift['z'].ravel()]
@@ -361,17 +467,21 @@ class ElectronLifetimeCalib(H5FlowStage):
             hit_mask = hit_mask & track_mask[...,np.newaxis]
 
             # bin hits onto track length
-            track_dir = tracks['start'] - tracks['end']
+            #track_dir = tracks['start'] - tracks['end']
+            track_dir = tracks['trajectory'][...,0,:] - tracks['trajectory'][...,-1,:]
             track_dir /= np.linalg.norm(track_dir, keepdims=True, axis=-1).clip(1e-300,None)
             
-            hit_s = xyz.reshape(tracks.shape + (-1,3)) - tracks['end'][...,np.newaxis,:]
+            #hit_s = xyz.reshape(tracks.shape + (-1,3)) - tracks['end'][...,np.newaxis,:]
+            hit_s = xyz.reshape(tracks.shape + (-1,3)) - tracks['trajectory'][...,np.newaxis,-1,:]
             hit_s = np.sum(hit_s * track_dir[...,np.newaxis,:], axis=-1)
             
             i_track = np.arange(np.prod(tracks.shape))
             i_track = np.broadcast_to(i_track[:,np.newaxis], i_track.shape + hits.shape[-1:])
 
-            max_length = tracks['length'].max()
-            s_bins,dx = np.linspace(0, max_length, int(np.ceil(max_length/self.DX))+1, retstep=True)
+            max_length = tracks['length'].filled(self.DX).max()
+            s_bins,dx = np.linspace(0, max_length, int(np.ceil((max_length)/self.DX))+1, retstep=True)
+
+            hit_mask = hit_mask & (hit_s > 0) & (hit_s < tracks['length'][...,np.newaxis])
             
             dq = np.histogramdd((i_track.ravel(), hit_s.ravel()),
                                 weights=(q * hit_mask).ravel(),
@@ -385,7 +495,7 @@ class ElectronLifetimeCalib(H5FlowStage):
 
             # calculate dq/dx
             dqdx = dq/dx
-            dqdx_mask = track_mask.ravel()[:,np.newaxis] & (dn > int(self.DX/(np.sqrt(3) * resources['Geometry'].pixel_pitch)))
+            dqdx_mask = track_mask.ravel()[:,np.newaxis] & (dn > 0) #= self.DX / (np.sqrt(3) * resources['Geometry'].pixel_pitch))
 
             # exclude the end-points (which can be biased)
             dqdx_mask[:,0] = False
@@ -395,6 +505,94 @@ class ElectronLifetimeCalib(H5FlowStage):
             dqdx_drift = t_drift / dn.clip(1, None)
 
             # fill dq/dx histogram
+            #self.dqdx_hist = self.dqdx_hist + np.histogramdd(
+            #    (dqdx_drift[dqdx_mask].ravel(), dqdx[dqdx_mask].ravel()),
+            #    bins=(self.drift_bins, self.dqdx_bins))[0]
+
+            # estimate instead using just track information
+            #track_dqdx = tracks['dq'] / np.linalg.norm(tracks['dx'], axis=-1).clip(0.1, None)
+            #track_pos = (tracks['trajectory'][...,1:,:] + tracks['trajectory'][...,:-1,:])/2
+            #track_z = track_pos[..., 2]
+            #track_drift = np.abs(track_z) - np.array(resources['Geometry'].regions)[...,2].max()
+            #track_drift = track_drift / resources['LArData'].v_drift
+            #self.dqdx_hist = self.dqdx_hist + np.histogramdd(
+            #    (track_drift.compressed(), track_dqdx.compressed()),
+            #    bins=(self.drift_bins, self.dqdx_bins))[0]
+
+            ## estimate instead using just hit information
+
+            # collect all hits in event
+            hits = hits.reshape(hits.shape[0:1] + (-1,))
+            initial_mask = hits.mask['id'].copy()
+            hits = condense_array(hits, initial_mask)
+            xyz = np.c_[condense_array(xyz[...,0].reshape(initial_mask.shape), initial_mask).ravel(),
+                        condense_array(xyz[...,1].reshape(initial_mask.shape), initial_mask).ravel(),
+                        condense_array(xyz[...,2].reshape(initial_mask.shape), initial_mask).ravel()]
+            xyz = xyz.reshape(hits.shape + (3,))
+
+            # calculate pairwise-distance
+            hit_dxyz = np.linalg.norm(xyz[...,:,np.newaxis,:] - xyz[...,np.newaxis,:,:], axis=-1)
+            if hit_dxyz.size == 0:
+                return
+            # find largest separation between hits
+            hit_imax_xyz = np.argmax(hit_dxyz * ~hits.mask['id'][...,np.newaxis,:] * (hit_dxyz < self.DX), axis=-1)
+            hit_max_xyz = np.take_along_axis(xyz[...,np.newaxis,:,:], hit_imax_xyz[...,np.newaxis,np.newaxis], axis=-2)
+            hit_max_dxyz = np.max(np.linalg.norm(hit_max_xyz - xyz[...,np.newaxis,:,:], axis=-1) * (hit_dxyz < self.DX), axis=-1)
+            hit_max_dxyz = hit_max_dxyz + resources['Geometry'].pixel_pitch
+
+            # only use hits within detector bulk and have good t0
+            hit_mask = ~hits.mask['id']
+            hit_mask = hit_mask & (events['n_ext_trigs'][:,np.newaxis] == 2)
+            hit_mask = hit_mask & resources['Geometry'].in_fid(xyz.reshape(-1,3), anode_fid=self.DX, field_cage_fid=self.DX, cathode_fid=self.DX).reshape(hits.shape)
+
+            # sum all hits in local region
+            hit_dq = np.sum(hits['q'][...,np.newaxis,:] * ~hits.mask['id'][...,np.newaxis,:] * (hit_dxyz < self.DX) * (hit_dxyz > 0), axis=-1)
+            hit_dn = np.sum(~hits.mask['id'][...,np.newaxis,:] * (hit_dxyz < self.DX) * (hit_dxyz > 0), axis=-1) + 1
+            hit_dq += hits['q']
+            hit_mask = hit_mask & (hit_dn >= np.floor(2 * self.DX / 4.434 - 1))
+            hit_dq = np.where(hit_mask, hit_dq, -1)
+            hit_dn = np.where(hit_mask, hit_dn, -1)
+
+            # use central hit for drift estimate
+            hit_drift = np.where(hit_mask, condense_array(drift['t_drift'].reshape(drift.shape[0],-1), initial_mask) * tick_size, -1)
+
             self.dqdx_hist = self.dqdx_hist + np.histogramdd(
-                (dqdx_drift[dqdx_mask].ravel(), dqdx[dqdx_mask].ravel()),
+                #(hit_drift.ravel(), hit_dq.ravel() / self.DX / 2),
+                (hit_drift.ravel(), hit_dq.ravel() / hit_max_dxyz.ravel()),
                 bins=(self.drift_bins, self.dqdx_bins))[0]
+
+            self.ntracks += np.sum(dqdx_mask.any(axis=-1))
+
+            # fill angle histograms
+            self.anode_hist = self.anode_hist + np.histogramdd(
+                (dqdx_drift[dqdx_mask].ravel(), np.broadcast_to(theta_anode.reshape(dqdx_mask.shape[:-1] + (1,)), dqdx_mask.shape)[dqdx_mask].ravel()),
+                bins=(self.drift_bins, self.angle_bins))[0]
+            self.zen_hist = self.zen_hist + np.histogramdd(
+                (dqdx_drift[dqdx_mask].ravel(), np.broadcast_to(theta_zen.reshape(dqdx_mask.shape[:-1] + (1,)), dqdx_mask.shape)[dqdx_mask].ravel()),
+                bins=(self.drift_bins, self.angle_bins))[0]
+
+            self.dndx_hist = self.dndx_hist + np.histogramdd(
+                #(dqdx_drift[dqdx_mask].ravel(), dn[dqdx_mask].ravel() / dx),
+                (hit_drift.ravel(), hit_dn.ravel() / hit_max_dxyz.ravel()),                
+                bins=(self.drift_bins, self.dndx_bins))[0]
+            
+            if resources['RunData'].is_mc and self.true_segments_dset_name in cache:
+                #true_segments = cache[self.true_segments_dset_name].reshape(hits.shape + (-1,))
+                
+                # fill true dE/dx histgram
+                #i_track = np.broadcast_to(i_track.reshape(true_segments.shape[:-1] + (1,)), true_segments.shape)
+                #hit_s = np.broadcast_to(hit_s.reshape(true_segments.shape[:-1] + (1,)), true_segments.shape)
+                #hit_mask = np.broadcast_to(hit_mask.reshape(true_segments.shape[:-1] + (1,)), true_segments.shape)
+                #hit_mask = hit_mask & ~(true_segments.mask['trackID']) & (np.abs(true_segments['pdgId']) == 13)
+
+                #dedx = np.histogramdd((i_track.ravel(), hit_s.ravel()),
+                #                      weights=(true_segments['dEdx'] * hit_mask).ravel(),
+                #                      bins=(np.arange(i_track.max() + 2), s_bins))[0]
+                #dn = np.histogramdd((i_track.ravel(), hit_s.ravel()),
+                #                      weights=hit_mask.ravel(),
+                #                      bins=(np.arange(i_track.max() + 2), s_bins))[0]
+                #dedx = dedx / dn.clip(1, None) # average over all true segments contributing to a hit
+                #self.dedx_hist = self.dedx_hist + np.histogramdd(
+                #    (dqdx_drift[dqdx_mask].ravel(), dedx[dqdx_mask].ravel()),
+                #    bins=(self.drift_bins, self.dedx_bins))[0]
+                pass

--- a/src/module0_flow/reco/light/adc64_event_generator.py
+++ b/src/module0_flow/reco/light/adc64_event_generator.py
@@ -84,7 +84,7 @@ class LightADC64EventGenerator(H5FlowGenerator):
     def event_dtype(self): return np.dtype([
         ('id', 'u8'),  # unique identifier
         ('event', 'i4'),  # event number in data file
-        ('sn', 'i4', self.n_adcs),  # adc serial number
+        ('sn', 'i4', (self.n_adcs,)),  # adc serial number
         ('ch', 'u1', (self.n_adcs, self.n_channels)),  # channel number
         ('utime_ms', 'u8', (self.n_adcs, self.n_channels)),  # unix time [ms since epoch]
         ('tai_ns', 'u8', (self.n_adcs, self.n_channels)),  # time since PPS [ns]

--- a/src/module0_flow/reco/light/wvfm_summary.py
+++ b/src/module0_flow/reco/light/wvfm_summary.py
@@ -67,6 +67,7 @@ class WaveformSummary(H5FlowStage):
 
         # then set up new datasets
         self.data_manager.create_dset(self.wvfm_summ_dset_name, dtype=self.dtype)
+        self.data_manager.create_ref(source_name, self.wvfm_summ_dset_name)
 
     def run(self, source_name, source_slice, cache):
         super(WaveformSummary, self).run(source_name, source_slice, cache)
@@ -108,4 +109,10 @@ class WaveformSummary(H5FlowStage):
             summ_arr['ch'] = ch.flat[mask]
             summ_arr['sn'] = sn.flat[mask]
             summ_arr['adc'] = adc.flat[mask]
+
+            ref = np.c_[(valid * event_data['id'][:,np.newaxis,np.newaxis])[valid], summ_slice]
+        else:
+            ref = np.empty((0,2))
+            
         self.data_manager.write_data(self.wvfm_summ_dset_name, summ_slice, summ_arr)
+        self.data_manager.write_ref(source_name, self.wvfm_summ_dset_name, ref)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -148,6 +148,13 @@ def michel_pdf_file(pytestconfig, tmp_path_factory):
                                       'michel_pdf-0.1.0.npz')))
 
 @pytest.fixture
+def background_pdf_file(pytestconfig, tmp_path_factory):
+    return next(maybe_fetch_from_url(pytestconfig, tmp_path_factory,
+                                     ('https://portal.nersc.gov/project/dune/'
+                                      'data/Module0/merged/reco_data/'
+                                      'bkg_pdf-0.0.0.npz')))
+
+@pytest.fixture
 def triplet_response_data_256_file(pytestconfig, tmp_path_factory):
     rv = next(maybe_fetch_from_url(pytestconfig, tmp_path_factory,
                                      ('https://portal.nersc.gov/project/dune/'

--- a/test/env-nompi.yaml
+++ b/test/env-nompi.yaml
@@ -13,3 +13,4 @@ dependencies:
   - pip
   - pip:
     - adc64format>=0.0.2
+    - pylandau

--- a/test/env.yaml
+++ b/test/env.yaml
@@ -20,4 +20,5 @@ dependencies:
     - pyyaml-include
     - h5py --no-binary=h5py
     - adc64format>=0.0.2
+    - pylandau
 

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -80,7 +80,7 @@ def light_reco_file(light_event_built_file, light_noise_file, light_signal_file,
                end_position=200)
 
     check_dsets(tmp_h5_file, (
-        'light/hits/data',
+        #'light/hits/data', # 2/13 - removed from workflow
         'light/t_ns/data',
     ))
 
@@ -99,7 +99,7 @@ def light_reco_wvfm_file(light_event_built_file, light_noise_file, light_signal_
                end_position=200)
 
     check_dsets(tmp_h5_file, (
-        'light/hits/data',
+        # 'light/hits/data', # 2/13 - removed from workflow
         'light/t_ns/data',
         'light/fwvfm/data',
         'light/deconv/data',

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -225,6 +225,7 @@ def broken_track_sim_file(combined_file_no_light, geometry_file, light_geometry_
 @pytest.fixture
 def stopping_muon_analysis_file(combined_file, geometry_file, light_geometry_file,
                                 proton_range_table, muon_range_table, michel_pdf_file,
+                                background_pdf_file,
                                 electron_lifetime_file, tmp_h5_file):
     print('Stopping muon analysis...')
     h5flow.run(['yamls/module0_flow/workflows/analysis/stopping_muons.yaml'],

--- a/yamls/module0_flow/workflows/analysis/light_intensity_map.yaml
+++ b/yamls/module0_flow/workflows/analysis/light_intensity_map.yaml
@@ -7,10 +7,12 @@ flow:
 
 resources:
   - !include yamls/module0_flow/resources/Geometry.yaml
+  - !include yamls/module0_flow/resources/RunData.yaml
+  - !include yamls/module0_flow/resources/LArData.yaml
 
 events:
   classname: H5FlowDatasetLoopGenerator
-  path: h5flow.modules
+  path: h5flow.modules.h5_flow_dataset_loop_generator
   dset_name: 'charge/events'
   params:
     chunk_size: 1
@@ -20,8 +22,18 @@ light_map:
   classname: LightIntensityMapGenerator # analysis/light_intensity_map.py
   path: module0_flow.analysis.light_intensity_map
   requires:
-    - name: 'light/swvfm'
-      path: ['light/events', 'light/swvfm']
+    - name: 'light/fwvfm'
+      path: ['light/events', 'light/fwvfm']
     - 'charge/hits'
+    - name: 'combined/q_calib_el'
+      path: ['charge/hits', 'combined/q_calib_el']
     - name: 'combined/hit_drift'
       path: ['charge/hits', 'combined/hit_drift']
+  params:
+    wvfm_dset_name: 'light/fwvfm'
+    charge_dset_name: 'combined/q_calib_el'
+    q_file: light_intensity_q.data.lut.v5.npz
+    s_file: light_intensity_s.data.lut.v5.npz
+    sum_files: True
+    charge_weighting: False
+    use_adc_channel_id: True

--- a/yamls/module0_flow/workflows/analysis/stopping_muons.yaml
+++ b/yamls/module0_flow/workflows/analysis/stopping_muons.yaml
@@ -2,7 +2,7 @@
 
 flow:
   source: events
-  stages: [truth_labels, noise_overlay, stopping_muon_sel, michel_id]
+  stages: [truth_labels, dropout, noise_overlay, stopping_muon_sel, michel_id, bkg_id]
 
 
 resources:
@@ -39,6 +39,26 @@ truth_labels:
 
     # output
     truth_labels_dset_name: 'analysis/muon_capture/truth_labels'
+
+
+dropout:
+  classname: Dropout
+  path: module0_flow.analysis.dropout
+  requires:
+    - 'charge/hits'
+    - name: 'combined/q_calib_el'
+      path: ['charge/hits', 'combined/q_calib_el']
+    - name: 'combined/hit_drift'
+      path: ['charge/hits', 'combined/hit_drift']
+    - name: 'analysis/stopping_muons/hit_profile'
+      path: ['charge/hits', 'analysis/stopping_muons/hit_profile']
+  params:
+    mask:
+      - 'charge/hits'
+      - 'combined/q_calib_el'
+      - 'combined/hit_drift'
+      - 'analysis/stopping_muons/hit_profile'
+    p: 0.03
 
 
 noise_overlay:
@@ -124,6 +144,8 @@ michel_id:
     - name: 'analysis/stopping_muons/hit_profile'
       path: ['charge/hits', 'analysis/stopping_muons/hit_profile']
   params:
+    charge_dset_name: 'combined/q_calib_el'
+    
     # configuration parameters
     michel_e_cut: 4000 # keV
     michel_nhit_cut: 7
@@ -132,3 +154,22 @@ michel_id:
     #generate_likelihood_pdf: True
     likelihood_pdf_filename: data/module0_flow/michel_pdf-0.1.0.npz
     # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/reco_data/michel_pdf-0.1.0.npz
+
+bkg_id:
+  classname: BackgroundID
+  path: module0_flow.analysis.background_id  
+  requires:
+    - 'charge/hits'
+    - name: 'combined/q_calib_el'
+      path: ['charge/hits', 'combined/q_calib_el']
+    - name: 'combined/hit_drift'
+      path: ['charge/hits', 'combined/hit_drift']
+    - name: 'analysis/stopping_muons/hit_profile'
+      path: ['charge/hits', 'analysis/stopping_muons/hit_profile']
+  params:
+    charge_dset_name: 'combined/q_calib_el'
+    
+    generate_likelihood_pdf: False
+    #generate_likelihood_pdf: True
+    likelihood_pdf_filename: h5flow_data/bkg_pdf-0.0.0.npz
+    # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/reco_data/bkg_pdf-0.0.0.npz

--- a/yamls/module0_flow/workflows/analysis/stopping_muons.yaml
+++ b/yamls/module0_flow/workflows/analysis/stopping_muons.yaml
@@ -70,7 +70,7 @@ noise_overlay:
       path: ['charge/hits', 'combined/q_calib_el']
   params:
     hits_name: 'charge/hits'
-    charge_name: 'combined/q_calib_el'
+    hit_charge_name: 'combined/q_calib_el'
     model_params:
       medm:
         type: 'scale_plus_binomial_noise'
@@ -79,8 +79,10 @@ noise_overlay:
         # <5% single channel dQ/dx shape residual for medium threshold runs btw 2-10ke/mm
         scale_factor: 1.007
         scale_width: 0.0667
-        binom_noise_scale: 9.946 # mV
-        binom_noise_width: 14.60 # mV
+        # binom_noise_scale: 9.946 # mV
+        # binom_noise_width: 14.60 # mV
+        binom_noise_scale: 11.2511 # mV, rescaled for simulated 222e/mV gain
+        binom_noise_width: 16.5158 # mV, rescaled for simulated 222e/mV gain
         binom_noise_prob: 0.2431
         binom_noise_asymm: 0.5425
 
@@ -91,8 +93,10 @@ noise_overlay:
         # <5% single channel dQ/dx shape residual for high threshold runs btw 2-10ke/mm
         scale_factor: 1.021
         scale_width: 0.04898
-        binom_noise_scale: 15.376 # mV
-        binom_noise_width: 17.676 # mV
+        # binom_noise_scale: 15.376 # mV
+        # binom_noise_width: 17.676 # mV
+        binom_noise_scale: 17.3936 # mV 
+        binom_noise_width: 19.9954 # mV
         binom_noise_prob: 0.2471
         binom_noise_asymm: 0.6020
 
@@ -124,13 +128,14 @@ stopping_muon_sel:
     cathode_fid_cut: 22 # mm
     profile_dx: 22 # mm
     larpix_gain:
-      mc: 250 # e/mV
+      mc: 222 # e/mV
       medm: 221 # e/mV
       high: 221 # e/mV
     curvature_rr_correction:
       mc: 1.0
       medm: 1.0
       high: 1.0
+
 
 michel_id:
   classname: MichelID

--- a/yamls/module0_flow/workflows/analysis/stopping_muons.yaml
+++ b/yamls/module0_flow/workflows/analysis/stopping_muons.yaml
@@ -176,5 +176,5 @@ bkg_id:
     
     generate_likelihood_pdf: False
     #generate_likelihood_pdf: True
-    likelihood_pdf_filename: h5flow_data/bkg_pdf-0.0.0.npz
+    likelihood_pdf_filename: data/module0_flow/bkg_pdf-0.0.0.npz
     # download link: https://portal.nersc.gov/project/dune/data/Module0/merged/reco_data/bkg_pdf-0.0.0.npz

--- a/yamls/module0_flow/workflows/charge/charge_event_reconstruction.yaml
+++ b/yamls/module0_flow/workflows/charge/charge_event_reconstruction.yaml
@@ -21,7 +21,7 @@ raw_events:
 
 
 chip_id_bit_flip_fix:
-  !include h5flow_yamls/reco/charge/BitFlipFix.yaml
+  !include yamls/module0_flow/reco/charge/BitFlipFix.yaml
 
 
 timestamp_corrector:

--- a/yamls/module0_flow/workflows/charge/charge_event_reconstruction.yaml
+++ b/yamls/module0_flow/workflows/charge/charge_event_reconstruction.yaml
@@ -37,7 +37,7 @@ hit_builder:
 
 
 hit_merger:
-  !include h5flow_yamls/reco/charge/HitMerger.yaml
+  !include yamls/module0_flow/reco/charge/HitMerger.yaml
 
 
 time_dependent_gain:

--- a/yamls/module0_flow/workflows/combined/electron_lifetime_calib.yaml
+++ b/yamls/module0_flow/workflows/combined/electron_lifetime_calib.yaml
@@ -1,11 +1,11 @@
 flow:
   source: events
-  stages: [electron_lifetime_calib]
+  stages: [noise_overlay, electron_lifetime_calib]
 
 resources:
-  - !include yamls/module0_flow/resources/RunData.yaml
-  - !include yamls/module0_flow/resources/Geometry.yaml
-  - !include yamls/module0_flow/resources/LArData.yaml
+  - !include h5flow_yamls/resources/RunData.yaml
+  - !include h5flow_yamls/resources/Geometry.yaml
+  - !include h5flow_yamls/resources/LArData.yaml
 
 events:
   classname: H5FlowDatasetLoopGenerator
@@ -14,19 +14,64 @@ events:
   params:
     chunk_size: 32
 
+noise_overlay:
+  classname: MCNoiseModelOverlay
+  path: module0_flow.analysis.mc_noise_model_overlay
+  requires:
+    - name: 'track_hits'
+      path: ['combined/tracklets/merged', 'charge/hits']    
+    - name: 'track_hit_q'
+      path: ['combined/tracklets/merged', 'charge/hits']
+  params:
+    hits_name: 'track_hits'
+    hit_charge_name: 'track_hit_q'
+    save_result: False
+    model_params:
+      medm:
+        type: 'scale_plus_binomial_noise'
+
+        # best fit to Module 0 medium threshold good runs on 4/10/2021
+        # <5% single channel dQ/dx shape residual for medium threshold runs btw 2-10ke/mm
+        scale_factor: 1.007
+        scale_width: 0.0667
+        binom_noise_scale: 11.2511 # mV, rescaled for simulated 222e/mV gain
+        binom_noise_width: 16.5158 # mV, rescaled for simulated 222e/mV gain
+        binom_noise_prob: 0.2431
+        binom_noise_asymm: 0.5425
+
+      high:
+        type: 'scale_plus_binomial_noise'
+
+        # best fit to Module 0 high threshold good runs on 4/10/2021
+        # <5% single channel dQ/dx shape residual for high threshold runs btw 2-10ke/mm
+        scale_factor: 1.021
+        scale_width: 0.04898
+        binom_noise_scale: 17.3936 # mV
+        binom_noise_width: 19.9954 # mV
+        binom_noise_prob: 0.2471
+        binom_noise_asymm: 0.6020
+
 electron_lifetime_calib:
   classname: ElectronLifetimeCalib
   path: module0_flow.reco.combined.electron_lifetime
   requires:
-    - 'combined/tracklets'
+    - 'combined/tracklets/merged'
     - name: 'track_hit_drift'
-      path: ['combined/tracklets', 'charge/hits', 'combined/hit_drift']
+      path: ['combined/tracklets/merged', 'charge/hits', 'combined/hit_drift']
     - name: 'track_hits'
-      path: ['combined/tracklets', 'charge/hits']
+      path: ['combined/tracklets/merged', 'charge/hits']
+    #- name: 'track_hit_q'
+    #  path: ['combined/tracklets/merged', 'charge/hits', 'combined/q_calib_el']
+    - name: 'track_hit_q'
+      path: ['combined/tracklets/merged', 'charge/hits']
+    - name: 'mc_truth/hits/tracks'
+      path: ['combined/tracklets/merged', 'charge/hits', 'charge/packets', 'mc_truth/tracks']
   params:
     hits_dset_name: 'track_hits'
-    charge_dset_name: 'track_hits'
+    charge_dset_name: 'track_hit_q'
     drift_dset_name: 'track_hit_drift'
-    tracks_dset_name: 'combined/tracklets'
+    tracks_dset_name: 'combined/tracklets/merged'
+    true_segments_dset_name: 'mc_truth/hits/tracks'
     mode: 'generate'
-    electron_lifetime_file: '/global/cscratch1/sd/pmadigan/electron_lifetime.npz'
+    electron_lifetime_file: '/pscratch/sd/p/pmadigan/electron_lifetime/electron_lifetime.npz'
+    #electron_lifetime_file: '/global/cscratch1/sd/pmadigan/electron_lifetime/electron_lifetime.npz'

--- a/yamls/module0_flow/workflows/light/light_event_reconstruction-keep_wvfm.yaml
+++ b/yamls/module0_flow/workflows/light/light_event_reconstruction-keep_wvfm.yaml
@@ -3,7 +3,7 @@
 
 flow:
   source: 'light/events'
-  stages: [timestamp_corrector, wvfm_filt, wvfm_deconv, wvfm_align, wvfm_sum, hit_finder]
+  stages: [timestamp_corrector, wvfm_filt, wvfm_align_filt, wvfm_deconv, wvfm_align, wvfm_sum]#, hit_finder]
 
 
 resources:
@@ -18,6 +18,17 @@ timestamp_corrector:
 
 wvfm_filt:
   !include yamls/module0_flow/reco/light/WaveformNoiseFilter.yaml
+
+
+wvfm_align_filt:
+  classname: WaveformAlign
+  path: module0_flow.reco.light.wvfm_align
+  requires:
+    - 'light/fwvfm'
+  params:
+    wvfm_dset_name: 'light/fwvfm'
+    busy_channel:
+        All: 0
 
 
 wvfm_deconv:

--- a/yamls/module0_flow/workflows/light/light_event_reconstruction.yaml
+++ b/yamls/module0_flow/workflows/light/light_event_reconstruction.yaml
@@ -3,7 +3,7 @@
 
 flow:
   source: 'light/events'
-  stages: [timestamp_corrector, wvfm_filt, wvfm_deconv, wvfm_align, sipm_hit_finder, wvfm_sum, hit_finder]
+  stages: [timestamp_corrector, wvfm_filt, wvfm_deconv, wvfm_align, wvfm_sum] #sipm_hit_finder, wvfm_sum, hit_finder]
 
   # remove waveforms from output file
   drop: ['light/wvfm', 'light/fwvfm', 'light/deconv']


### PR DESCRIPTION
I finally worked in all the various bug fixes and minor improvements that I've made of the past month or so. It's not all related to a coherent theme, but it seemed better to just do one large PR rather than an individual on per few line change. I think I'll not squash this one when I merge, in case something needs to be reverted.

Summary:
 - Adds a background likelihood score for hits (muon capture analysis)
 - Adds a "dropout" module for estimating the impact of data corruption with v2a chip (muon capture analysis)
 - Makes cuts in light map analysis stronger and adds the ability to generate the map per SiPM
 - Changes the gain used for simulation files to 222e/mV to match the most recent production run
 - Adds noise overlay for simulation when using the electron lifetime calibration workflow, also saves truth information and modifies the dQ/dx algorithm
 - Adds alignment data for filtered waveforms in light reconstruction (with waveforms)
 - Handles edge cases that were causing crashes for delayed signal processing and noise overlay (muon capture analysis)
 - Fixes stopping muon truth labelling bugs (muon capture analysis)
 - Fixes hidden biases in seed pt selection (muon capture analysis)
 - Optimizes the binned time window raw event builder algorithm to run *much* faster
 - Fixes a bug in the ADC64 light event generator that occurs in newer versions of numpy and when generating events from 1 ADC file
 - Adds references between the parent dataset and waveform summary dataset
 - Adds reference datasizes to plots created by the map_file.py script
 - Gracefully handles matching errors in merge_files.py script