### PR TITLE
Add more logging to various modules with helpful info

### DIFF
--- a/src/module0_flow/analysis/background_id.py
+++ b/src/module0_flow/analysis/background_id.py
@@ -223,6 +223,7 @@ class BackgroundID(H5FlowStage):
             bkg_label['bkg_q'] = np.sum(hit_q * (hit_score < self.score_cut) * ~muon_flag, axis=-1)            
             bkg_label['muon_dir'] = mu_dir
             bkg_label['stop_pt'] = mu_end
+        logging.info(f'total background hits (per event): {bkg_label["bkg_nhit"].tolist()}')
 
         hit_mask = ~hits['id'].mask
         hit_label = np.empty(hit_mask.sum(), dtype=self.hit_label_dtype)
@@ -230,6 +231,7 @@ class BackgroundID(H5FlowStage):
             hit_label['score'] = hit_score[hit_mask]
             hit_label['bkg_flag'] = ((hit_score < self.score_cut) & ~muon_flag)[hit_mask]
             hit_label['muon_flag'] = muon_flag[hit_mask]
+        logging.info(f'total background hits (per batch): {hit_label["bkg_flag"].sum()}')
 
         # write to file
         self.data_manager.reserve_data(self.bkg_label_dset_name, source_slice)

--- a/src/module0_flow/analysis/michel_id.py
+++ b/src/module0_flow/analysis/michel_id.py
@@ -294,6 +294,7 @@ class MichelID(H5FlowStage):
             michel_label['muon_dir'] = mu_dir
             michel_label['stop_pt'] = mu_end
             michel_label['michel_end'] = michel_end
+        logging.info(f'total Michel hits (per {len(ev)} events): {michel_label["michel_nhit"].tolist()}')
 
         hit_mask = ~hits['id'].mask
         hit_label = np.empty(hit_mask.sum(), dtype=self.hit_label_dtype)
@@ -301,6 +302,7 @@ class MichelID(H5FlowStage):
             hit_label['score'] = hit_score[hit_mask]
             hit_label['michel_flag'] = ((hit_score > 0) & ~muon_flag)[hit_mask]
             hit_label['muon_flag'] = muon_flag[hit_mask]
+        logging.info(f'total Michel hits (per batch): {hit_label["michel_flag"].sum()}')
 
         # write to file
         self.data_manager.reserve_data(self.michel_label_dset_name, source_slice)

--- a/src/module0_flow/reco/charge/charge2light.py
+++ b/src/module0_flow/reco/charge/charge2light.py
@@ -113,9 +113,9 @@ class Charge2LightAssociation(H5FlowStage):
 
         if self.rank == 0:
             self.total_matched_light = self.matched_light.clip(0,1).sum()
-            trigger_eff = self.total_matched_triggers/self.total_charge_triggers
-            event_eff = self.total_matched_events/self.total_charge_events
-            light_eff = self.total_matched_light/self.total_light_events
+            trigger_eff = self.total_matched_triggers/max(self.total_charge_triggers, 1)
+            event_eff = self.total_matched_events/max(self.total_charge_events, 1)
+            light_eff = self.total_matched_light/max(self.total_light_events, 1)
             print(f'Total charge trigger matching: {self.total_matched_triggers}/{self.total_charge_triggers} ({trigger_eff:0.04f})')
             print(f'Total charge event matching: {self.total_matched_events}/{self.total_charge_events} ({event_eff:0.04f})')
             print(f'Total light event matching: {self.total_matched_light}/{self.total_light_events} ({light_eff:0.04f})')

--- a/src/module0_flow/reco/charge/charge2light.py
+++ b/src/module0_flow/reco/charge/charge2light.py
@@ -4,6 +4,7 @@ import numpy.lib.recfunctions as rfn
 import logging
 
 from h5flow.core import H5FlowStage, resources
+from h5flow import H5FLOW_MPI
 import module0_flow.util.units as units
 
 
@@ -57,6 +58,14 @@ class Charge2LightAssociation(H5FlowStage):
         self.unix_ts_window = params.get('unix_ts_window', self.default_unix_ts_window)
         self.ts_window = params.get('ts_window', self.default_ts_window)
 
+        self.total_charge_events = 0
+        self.total_charge_triggers = 0
+        self.total_light_events = 0
+        self.total_matched_triggers = 0
+        self.total_matched_events = 0
+        self.matched_light = np.zeros((0,), dtype=bool)
+        self.total_matched_light = 0
+
     def init(self, source_name):
         super(Charge2LightAssociation, self).init(source_name)
 
@@ -82,11 +91,36 @@ class Charge2LightAssociation(H5FlowStage):
         self.light_unix_ts = self.light_unix_ts * (units.ms / units.s)  # convert ms -> s
         self.light_ts = self.data_manager.get_dset(self.light_event_dset_name)['tai_ns'][:]
         self.light_ts = ma.array(self.light_ts, mask=~self.light_event_mask).mean(axis=-1).mean(axis=-1)
-        self.light_ts = self.light_ts % int(1e9)
+        if not resources['RunData'].is_mc:
+            self.light_ts = self.light_ts % int(1e9)
         self.light_ts = self.light_ts * (units.ns / resources['RunData'].crs_ticks)  # convert ns -> larpix clock ticks
 
         self.light_unix_ts_start = self.light_unix_ts.min()
         self.light_unix_ts_end = self.light_unix_ts.max()
+
+        self.total_light_events = len(self.light_unix_ts)
+        self.matched_light = np.zeros((self.total_light_events,), dtype=bool)        
+
+    def finish(self, source_name):
+        super(Charge2LightAssociation, self).finish(source_name)
+        
+        if H5FLOW_MPI:
+            self.total_charge_events = self.comm.reduce(self.total_charge_events, root=0)
+            self.total_charge_triggers = self.comm.reduce(self.total_charge_triggers, root=0)
+            self.total_matched_triggers = self.comm.reduce(self.total_matched_triggers, root=0)
+            self.total_matched_events = self.comm.reduce(self.total_matched_events, root=0)
+            self.matched_light = self.comm.reduce(self.matched_light, root=0)
+
+        if self.rank == 0:
+            self.total_matched_light = self.matched_light.clip(0,1).sum()
+            trigger_eff = self.total_matched_triggers/self.total_charge_triggers
+            event_eff = self.total_matched_events/self.total_charge_events
+            light_eff = self.total_matched_light/self.total_light_events
+            print(f'Total charge trigger matching: {self.total_matched_triggers}/{self.total_charge_triggers} ({trigger_eff:0.04f})')
+            print(f'Total charge event matching: {self.total_matched_events}/{self.total_charge_events} ({event_eff:0.04f})')
+            print(f'Total light event matching: {self.total_matched_light}/{self.total_light_events} ({light_eff:0.04f})')
+            
+            
 
     def match_on_timestamp(self, charge_unix_ts, charge_pps_ts):
         unix_ts_start = charge_unix_ts.min()
@@ -97,7 +131,7 @@ class Charge2LightAssociation(H5FlowStage):
             # no overlap, short circuit
             return np.empty((0, 2), dtype=int)
 
-        # subselect only portion of light events that overlaps with timestamps
+        # subselect only portion of light events that overlaps with unix timestamps
         i_min = np.argmax((self.light_unix_ts >= unix_ts_start - self.unix_ts_window))
         i_max = len(self.light_unix_ts) - 1 - np.argmax((self.light_unix_ts <= unix_ts_end + self.unix_ts_window)[::-1])
         sl = slice(i_min, i_max)
@@ -111,8 +145,7 @@ class Charge2LightAssociation(H5FlowStage):
         else:
             idcs = np.empty((0,2), dtype=int)
 
-        return idcs
-        
+        return idcs        
 
     def run(self, source_name, source_slice, cache):
         super(Charge2LightAssociation, self).run(source_name, source_slice, cache)
@@ -135,7 +168,7 @@ class Charge2LightAssociation(H5FlowStage):
                 ext_trigs_idcs = ext_trigs_idcs.data[ext_trigs_mask]
                 ext_trigs_unix_ts = np.broadcast_to(event_data['unix_ts'].reshape(-1, 1), ext_trigs_data.shape)[ext_trigs_mask]
                 ext_trigs_ts = ext_trigs_all['ts']
-            
+
                 idcs = self.match_on_timestamp(ext_trigs_unix_ts, ext_trigs_ts)
 
                 if len(idcs):
@@ -143,9 +176,18 @@ class Charge2LightAssociation(H5FlowStage):
                     ev_id_bcast = np.broadcast_to(ev_id[:,np.newaxis], ext_trigs_mask.shape)
                     ev_ref = np.unique(np.append(ev_ref, np.c_[ev_id_bcast[ext_trigs_mask][idcs[:, 0]], idcs[:, 1]], axis=0), axis=0)
 
+                logging.info(f'found charge/light match on {len(ext_trig_ref)}/{ext_trigs_mask.sum()} triggers')
+                logging.info(f'found charge/light match on {len(ev_ref)}/{len(event_data)} events')
+                self.total_charge_triggers += ext_trigs_mask.sum()
+                self.total_matched_triggers += len(np.unique(ext_trig_ref[:,0]))
+                self.total_matched_events += len(np.unique(ev_ref[:,0]))
+                self.matched_light[np.unique(ext_trig_ref[:,1])] = True
+
         # write references
         # ext trig -> light event
         self.data_manager.write_ref(self.ext_trigs_dset_name, self.light_event_dset_name, ext_trig_ref)
 
         # charge event -> light event
         self.data_manager.write_ref(self.events_dset_name, self.light_event_dset_name, ev_ref)
+
+        self.total_charge_events += len(event_data)

--- a/src/module0_flow/reco/charge/raw_event_generator.py
+++ b/src/module0_flow/reco/charge/raw_event_generator.py
@@ -358,7 +358,8 @@ class RawEventGenerator(H5FlowGenerator):
 
         logging.info(f'total packets: {len(block)}')
         logging.info(f'valid entries: {mask.sum()}')
-        logging.info(f'valid parity: {block["valid_parity"].astype(bool).sum()}')
+        logging.info(f'valid parity: {(block["valid_parity"].astype(bool) & (block["packet_type"] == 0)).sum()}')
+        logging.info(f'data: {(block["packet_type"] == 0).sum()}')        
         logging.info(f'messages: {(block["packet_type"] == 4).sum()}')
         logging.info(f'triggers: {(block["packet_type"] == 7).sum()}')
         logging.info(f'syncs: {(block["packet_type"] == 6).sum()}')        

--- a/src/module0_flow/reco/combined/electron_lifetime.py
+++ b/src/module0_flow/reco/combined/electron_lifetime.py
@@ -422,12 +422,13 @@ class ElectronLifetimeCalib(H5FlowStage):
             # even if hits are slightly late (i.e. in the case of multiple self-triggers on
             # a channel from a track crossing the cathode)
 
-            f = ma.masked_where(
-                drift['t_drift'].mask,
-                np.where(
-                    (drift['t_drift'] >= 0) & (drift['t_drift'] * tick_size * v_drift <= max_drift),
-                    np.exp((drift['t_drift'] * tick_size) / electron_lifetime[:,np.newaxis]),
-                    1)
+            with np.errstate(over='ignore'):
+                f = ma.masked_where(
+                    drift['t_drift'].mask,
+                    np.where(
+                        (drift['t_drift'] >= 0) & (drift['t_drift'] * tick_size * v_drift <= max_drift),
+                        np.exp((drift['t_drift'] * tick_size) / electron_lifetime[:,np.newaxis]),
+                        1)
                 )
             q = f * q
 


### PR DESCRIPTION
 - Adds a number of logging statements to modules that have some helpful info (like number of packets with bad parity, event matching fraction, etc)
 - Also fixes a few warnings that were being produced due to nans (that were already being handled well, just giving warnings)
 - Also fixes the definition of `p` in the dropout module

@kwresilo this contains the light matching metrics, I'll double check that it passes tests and then merge into develop
