### PR TITLE
Add GENIE particle stack to ndflow output

### DIFF
--- a/src/proto_nd_flow/reco/charge/raw_event_generator.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_generator.py
@@ -81,6 +81,7 @@ class RawEventGenerator(H5FlowGenerator):
     default_event_builder_config = dict()
     default_packets_dset_name = 'charge/packets'
     default_mc_events_dset_name = 'mc_truth/interactions'
+    default_mc_stack_dset_name = 'mc_truth/stack'
     default_mc_tracks_dset_name = 'mc_truth/tracks'
     default_mc_trajectories_dset_name = 'mc_truth/trajectories'
     default_mc_packet_fraction_dset_name = 'mc_truth/packet_fraction'
@@ -109,6 +110,7 @@ class RawEventGenerator(H5FlowGenerator):
         self.packets_dset_name = params.get('packets_dset_name', self.default_packets_dset_name)
         self.raw_event_dset_name = self.dset_name
         self.mc_events_dset_name = params.get('mc_events_dset_name', self.default_mc_events_dset_name)
+        self.mc_stack_dset_name = params.get('mc_stack_dset_name', self.default_mc_stack_dset_name)
         self.mc_tracks_dset_name = params.get('mc_tracks_dset_name', self.default_mc_tracks_dset_name)
         self.mc_trajectories_dset_name = params.get('mc_trajectories_dset_name', self.default_mc_trajectories_dset_name)
         self.mc_packet_fraction_dset_name = params.get('mc_packet_fraction_dset_name', self.default_mc_packet_fraction_dset_name)
@@ -150,6 +152,7 @@ class RawEventGenerator(H5FlowGenerator):
             self.mc_tracks = self.input_fh['tracks']
             self.mc_trajectories = self.input_fh['trajectories']
             self.mc_events = self.input_fh['genie_hdr']
+            self.mc_stack = self.input_fh['genie_stack']
 
         # initialize data objects
         self.data_manager.create_dset(self.raw_event_dset_name, dtype=self.raw_event_dtype)
@@ -175,12 +178,14 @@ class RawEventGenerator(H5FlowGenerator):
                                         mc_tracks_dset_name=self.mc_tracks_dset_name,
                                         mc_trajectories_dset_name=self.mc_trajectories_dset_name,
                                         mc_events_dset_name=self.mc_events_dset_name,
+                                        mc_stack_dset_name=self.mc_stack_dset_name,
                                         mc_packet_fraction_dset_name=self.mc_packet_fraction_dset_name)
 
             self.data_manager.create_dset(self.mc_packet_fraction_dset_name, dtype=self.mc_assn['fraction'].dtype)
             self.data_manager.create_ref(self.packets_dset_name, self.mc_packet_fraction_dset_name)
 
             # copy datasets from source file
+            # MC interaction summary info
             self.data_manager.create_dset(self.mc_events_dset_name, dtype=self.mc_events.dtype)
             ninter = len(self.mc_events)
             inter_sl = slice(
@@ -190,6 +195,16 @@ class RawEventGenerator(H5FlowGenerator):
             self.data_manager.write_data(self.mc_events_dset_name, inter_sl,
                                          self.mc_events[inter_sl])
 
+            # MC generator particle stack
+            self.data_manager.create_dset(self.mc_stack_dset_name, dtype=self.mc_stack.dtype)
+            nstack = len(self.mc_stack)
+            stack_sl = slice(
+                ceil(nstack / self.size * self.rank),
+                ceil(nstack / self.size * (self.rank + 1)))
+            self.data_manager.reserve_data(self.mc_stack_dset_name, stack_sl)
+            self.data_manager.write_data(self.mc_stack_dset_name, stack_sl, self.mc_stack[stack_sl])
+
+            # edep-sim energy segments/deposits
             self.data_manager.create_dset(self.mc_tracks_dset_name, dtype=self.mc_tracks.dtype)
             ntracks = len(self.mc_tracks)
             # track_sl = slice(
@@ -203,6 +218,7 @@ class RawEventGenerator(H5FlowGenerator):
                 self.mc_tracks_dset_name, track_sl,
                 self.mc_tracks[track_sl])
 
+            # edep-sim trajectories
             self.data_manager.create_dset(self.mc_trajectories_dset_name, dtype=self.mc_trajectories.dtype)
             ntraj = len(self.mc_trajectories)
             # traj_sl = slice(


### PR DESCRIPTION
Creates a new dataset `mc_truth/stack` for the GENIE particle stack. Also creates references between interactions-->stack and stack-->trajectories.

Needs `genie_stack` to have `trackID` field to work properly in the larndsim input files. This is created and filled during the ROOT->H5 conversion stage.