### PR TITLE
Feature hit refs

### DIFF
--- a/scripts/proto_nd_scripts/get_proto_nd_input.sh
+++ b/scripts/proto_nd_scripts/get_proto_nd_input.sh
@@ -8,7 +8,7 @@ HERE=`pwd`
 cd ${DATA_DIR}
 
 # tile layout describing a *single* module (fix me)
-curl -O https://portal.nersc.gov/project/dune/data/2x2/simulation/kwood_dev/proto_nd_flow_inputs/multi_tile_layout-2.3.16.yaml 
+curl -O https://portal.nersc.gov/project/dune/data/2x2/simulation/kwood_dev/proto_nd_flow_inputs/multi_tile_layout-2.4.16.yaml 
 
 # 2x2 detector description
 curl -O https://portal.nersc.gov/project/dune/data/2x2/simulation/kwood_dev/proto_nd_flow_inputs/2x2.yaml

--- a/src/proto_nd_flow/reco/charge/calib_hit_merger.py
+++ b/src/proto_nd_flow/reco/charge/calib_hit_merger.py
@@ -321,7 +321,8 @@ class CalibHitMerger(H5FlowStage):
         ref = ref[np.argsort(ref[:, 0])]
 
         # finally, write the references
-        self.data_manager.write_ref(self.hits_name, self.merged_name, np.c_[merge_idx, merge_idx])
-        self.data_manager.write_ref(self.merged_name,self.mc_hit_frac_dset_name,ref)
+        self.data_manager.write_ref(self.hits_name, self.merged_name, ref)
+        self.data_manager.write_ref(self.merged_name,self.mc_hit_frac_dset_name,np.c_[merge_idx,merge_idx])
         ev_ref = np.c_[(np.indices(merged_mask.shape)[0] + source_slice.start)[~merged_mask], merge_idx]
         self.data_manager.write_ref(source_name, self.merged_name, ev_ref)
+        self.data_manager.write_ref(self.events_dset_name, self.merged_name, ev_ref)

--- a/src/proto_nd_flow/reco/charge/raw_event_generator.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_generator.py
@@ -82,7 +82,7 @@ class RawEventGenerator(H5FlowGenerator):
     default_packets_dset_name = 'charge/packets'
     default_mc_events_dset_name = 'mc_truth/interactions'
     default_mc_stack_dset_name = 'mc_truth/stack'
-    default_mc_tracks_dset_name = 'mc_truth/tracks'
+    default_mc_tracks_dset_name = 'mc_truth/segments'
     default_mc_trajectories_dset_name = 'mc_truth/trajectories'
     default_mc_packet_fraction_dset_name = 'mc_truth/packet_fraction'
 
@@ -149,10 +149,10 @@ class RawEventGenerator(H5FlowGenerator):
         self.packets_dtype = self.packets.dtype
         if self.is_mc:
             self.mc_assn = self.input_fh['mc_packets_assn']
-            self.mc_tracks = self.input_fh['tracks']
+            self.mc_tracks = self.input_fh['segments']
             self.mc_trajectories = self.input_fh['trajectories']
-            self.mc_events = self.input_fh['genie_hdr']
-            self.mc_stack = self.input_fh['genie_stack']
+            self.mc_events = self.input_fh['mc_hdr']
+            self.mc_stack = self.input_fh['mc_stack']
 
         # initialize data objects
         self.data_manager.create_dset(self.raw_event_dset_name, dtype=self.raw_event_dtype)
@@ -243,23 +243,23 @@ class RawEventGenerator(H5FlowGenerator):
 
             # create references between trajectories and tracks
             # eventID --> vertexID for latest production files
-            intr_evid = self.mc_events['vertexID'][:]
-            stack_evid = self.mc_stack['vertexID'][:]
-            traj_evid = self.mc_trajectories['vertexID'][:]
-            tracks_evid = self.mc_tracks['vertexID'][:]
+            intr_evid = self.mc_events['vertex_id'][:]
+            stack_evid = self.mc_stack['vertex_id'][:]
+            traj_evid = self.mc_trajectories['vertex_id'][:]
+            tracks_evid = self.mc_tracks['vertex_id'][:]
             evs, ev_traj_start, ev_track_start = np.intersect1d(
                 traj_evid, tracks_evid, return_indices=True)
             evs, ev_traj_end, ev_track_end = np.intersect1d(
                 traj_evid[::-1], tracks_evid[::-1], return_indices=True)
-            ev_traj_end = len(self.mc_trajectories['vertexID']) - ev_traj_end
-            ev_track_end = len(self.mc_tracks['vertexID']) - ev_track_end
+            ev_traj_end = len(self.mc_trajectories['vertex_id']) - ev_traj_end
+            ev_track_end = len(self.mc_tracks['vertex_id']) - ev_track_end
             truth_slice = slice(
                 ceil(len(evs) / self.size * self.rank),
                 ceil(len(evs) / self.size * (self.rank + 1)))
 
-            stack_trackid = self.mc_stack['trackID'][:]
-            traj_trackid = self.mc_trajectories['trackID'][:]
-            tracks_trackid = self.mc_tracks['trackID'][:]
+            stack_trackid = self.mc_stack['traj_id'][:]
+            traj_trackid = self.mc_trajectories['traj_id'][:]
+            tracks_trackid = self.mc_tracks['traj_id'][:]
             iter_ = tqdm(range(truth_slice.start, truth_slice.stop), smoothing=1, desc='generating truth references') if self.rank == 0 else range(truth_slice.start, truth_slice.stop)
             for i in iter_:
                 if i < len(evs):

--- a/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
@@ -3,16 +3,17 @@ path: proto_nd_flow.reco.charge.calib_hit_merger
 requires:
   - 'charge/events'
   - 'charge/calib_prompt_hits'
-  - name: 'charge/calib_prompt_hits_idx'
-    path: ['charge/calib_prompt_hits']
-    index_only: True
+  - name: 'packet_frac_backtrack'
+    path: ['charge/calib_prompt_hits','charge/packets','mc_truth/packet_fraction']
+  - name: 'packet_seg_backtrack'
+    path: ['charge/calib_prompt_hits','charge/packets','mc_truth/segments']
+
+
 params:
   # inputs
   events_dset_name: 'charge/events'
   hits_name: 'charge/calib_prompt_hits'
-  hit_charge_name: 'charge/calib_prompt_hits'
-  hits_idx_name: 'charge/calib_prompt_hits'
-
+  mc_hit_frac_dset_name: 'mc_truth/calib_final_hit_backtrack'
   merged_name: 'charge/calib_final_hits'
   merge_cut: 65 # merge hits with delta t < merge_cut [CRS ticks]
   max_merge_steps: 50 # max number of iterations when merging

--- a/yamls/proto_nd_flow/reco/charge/RawEventGenerator.yaml
+++ b/yamls/proto_nd_flow/reco/charge/RawEventGenerator.yaml
@@ -6,6 +6,7 @@ params:
   packets_dset_name: 'charge/packets'
 
   # configuration parameters
+  mc_tracks_dset_name: 'mc_truth/segments'
   buffer_size: 384000
   nhit_cut: 100
   sync_noise_cut: [1000000, 11000000] # 1e6 cut based on Brooke's study

--- a/yamls/proto_nd_flow/resources/Geometry.yaml
+++ b/yamls/proto_nd_flow/resources/Geometry.yaml
@@ -3,5 +3,5 @@ path: proto_nd_flow.resources.geometry
 params:
   path: 'geometry_info'
   det_geometry_file: 'data/proto_nd_flow/2x2.yaml'
-  crs_geometry_file: 'data/proto_nd_flow/multi_tile_layout-2.3.16.yaml'
+  crs_geometry_file: 'data/proto_nd_flow/multi_tile_layout-2.4.16.yaml'
   lrs_geometry_file: 'data/proto_nd_flow/light_module_desc-1.0.0.yaml'

--- a/yamls/proto_nd_flow/resources/RunData.yaml
+++ b/yamls/proto_nd_flow/resources/RunData.yaml
@@ -14,4 +14,4 @@ params:
     charge_thresholds: 'medm'
     is_mc: True
     crs_ticks: 0.1 # us
-    lrs_ticks: 0.01 # us
+    lrs_ticks: 0.016 # us


### PR DESCRIPTION
This PR includes a new dataset into the calib hit merger to be used for more convenient backtracking. Previously one needed to go from merged hits --> unmerged hits --> packets --> segment contribution to back track. This new data set does all of that internally and builds, for each hit, a list of segment_id's that contribute to the hit and a corresponding list of fractional contributions.

See attached example that gathers all of the merged hits in an event and uses this new dataset to gather all contributing segments,

![Screenshot from 2023-07-25 13-34-15](https://github.com/DUNE/ndlar_flow/assets/18149958/96827ed8-271b-49f6-a88f-67b4caebe528)
