### PR TITLE
Backtracking for prompt hits

### DIFF
--- a/scripts/proto_nd_scripts/run_proto_nd_flow_example.sh
+++ b/scripts/proto_nd_scripts/run_proto_nd_flow_example.sh
@@ -34,7 +34,7 @@ cd ../../
 # avoid being asked if we want to overwrite the file if it exists.
 # this is us answering "yes".
 if [ -e $OUTPUT_FILE ]; then
-    rm -i $OUTPUT_FILE
+    rm $OUTPUT_FILE
 fi
 
 $H5FLOW_CMD -c $WORKFLOW1 $WORKFLOW2 $WORKFLOW3 $WORKFLOW4 $WORKFLOW5 -i $INPUT_FILE -o $OUTPUT_FILE

--- a/yamls/proto_nd_flow/reco/charge/CalibHitBuilder.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibHitBuilder.yaml
@@ -8,6 +8,11 @@ requires:
   - name: 'charge/packets_index'
     path: ['charge/packets']
     index_only: True
+  - name: 'packet_frac_backtrack'
+    path: ['charge/packets','mc_truth/packet_fraction']
+  - name: 'packet_seg_backtrack'
+    path: ['charge/packets','mc_truth/segments']
+
 params:
   # inputs
   events_dset_name: 'charge/events'
@@ -15,9 +20,11 @@ params:
   packets_index_name: 'charge/packets_index'
   raw_hits_dset_name: 'charge/raw_hits'
   t0_dset_name: 'combined/t0'
+  max_contrib_segments: 10
 
   # output
   calib_hits_dset_name: 'charge/calib_prompt_hits'
+  mc_hit_frac_dset_name: 'mc_truth/calib_prompt_hit_backtrack'
 
   # configuration parameters
 

--- a/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
@@ -13,11 +13,11 @@ params:
   # inputs
   events_dset_name: 'charge/events'
   hits_name: 'charge/calib_prompt_hits'
-  mc_hit_frac_dset_name: 'mc_truth/calib_final_hit_backtrack'
-  merged_name: 'charge/calib_final_hits'
   max_contrib_segments: 200
   merge_cut: 65 # merge hits with delta t < merge_cut [CRS ticks]
   max_merge_steps: 50 # max number of iterations when merging
                        # adjacent packets in time on the same channel
-
+  # outputs
+  merged_name: 'charge/calib_final_hits'
+  mc_hit_frac_dset_name: 'mc_truth/calib_final_hit_backtrack'
 


### PR DESCRIPTION
Backtracking treatment for 'calib_prompt_hits' that mirrors that of 'calib_final_hits'. A demonstration of the generic backtracking:

```
def draw_event_bt(infile,event_number,hits_dset_name):
    hit_ref_slice = infile['charge/events/ref/charge/'+hits_dset_name+'/ref_region'][event_number]
    hits = infile['charge/'+hits_dset_name+'/data'][hit_ref_slice[0]:hit_ref_slice[1]]
    hits_bt = infile['mc_truth/'+hits_dset_name[:-1]+'_backtrack/data'][hit_ref_slice[0]:hit_ref_slice[1]]
    segments = infile['mc_truth/segments/data']
    print('event', event_number,':', 'number of',hits_dset_name,'=',len(hits))

    # plot al hits from this event in z-y:
    plt.scatter(hits['z'],hits['x'],c='b',alpha=1.0,s=1.2)

    # plot all of the back tracked segment positions:
    for hit in hits_bt:
        for cont in range(len(hit['fraction'])):
            if abs(hit['fraction'][cont]) > 0.0001:
                seg_id = hit['segment_id'][cont]
                seg = segments[seg_id]
                if not seg['segment_id'] == seg_id:
                    print('WARNING: segment id not the same as segment index!')
                plt.plot([seg['z_start'],seg['z_end']],[seg['x_start'],seg['x_end']],c='r',alpha=0.5)
    plt.show()

# demonstration of generic backtracking
f = h5py.File("/global/cfs/cdirs/dune/users/kwood/ndlar_flow_prompt_bt/ndlar_flow/scripts/proto_nd_scripts/"
                +"MiniRun4_1E19_RHC.larnd.00123.LARNDSIM.proto_nd_flow.h5","r")

draw_event_bt(f,15,'calib_final_hits')
draw_event_bt(f,15,'calib_prompt_hits')
```
Produces the following output:
Example 1:
![calib_hit_bt_example1](https://github.com/DUNE/ndlar_flow/assets/18149958/caef74ac-10d2-43e5-a453-9018498097ed)

Example 2 - small event, but shows the hit merging in action:
![calib_hit_bt_example2](https://github.com/DUNE/ndlar_flow/assets/18149958/58490692-8f84-4634-887f-0ee5324248b4)
