### PR TITLE
Remove large initialised arrays

### DIFF
--- a/src/proto_nd_flow/reco/charge/calib_hit_merger.py
+++ b/src/proto_nd_flow/reco/charge/calib_hit_merger.py
@@ -241,7 +241,6 @@ class CalibHitMerger(H5FlowStage):
 
         # calculate segment contributions for each merged hit
         if has_mc_truth:
-            tmp_bt = np.full(shape=new_hits.shape+(2,self.max_contrib_segments),fill_value=0.)
             back_track = np.full(shape=new_hits.shape,fill_value=0.,dtype=self.hit_frac_dtype)
             # loop over hits
             for hit_it, hit in np.ndenumerate(new_hits):
@@ -250,12 +249,12 @@ class CalibHitMerger(H5FlowStage):
                 # renormalize the fractional contributions given the charge weighted average
                 norm = np.sum(np.multiply(hit_contr[0],hit_contr[1]))
                 if norm == 0.: norm = 1.
-                tmp_bt[hit_it][0] = np.multiply(hit_contr[0],hit_contr[1])/norm # fractional contributions
-                tmp_bt[hit_it][1] = hit_contr[2] # segment_ids
+                tmp_bt_0 = np.multiply(hit_contr[0],hit_contr[1])/norm # fractional contributions
+                tmp_bt_1 = hit_contr[2] # segment_ids
 
                 # merge unique track contributions
                 track_dict = defaultdict(lambda:0)
-                for track in zip(tmp_bt[hit_it][0],tmp_bt[hit_it][1]):
+                for track in zip(tmp_bt_0,tmp_bt_1):
                     track_dict[track[1]] += track[0]
                 track_dict = dict(track_dict)
                 bt_unique_segs = np.array(list(track_dict.keys()))


### PR DESCRIPTION
tmp_bt is a large array initialised in the current develop branch and only a small number of its entries are used. When we skip initialisation and only define the entries that are needed for the program to run, the total memory usage of ndlar_flow goes from 4.7 GB to 4.0 GB. The outputs are identical, as determined by MD5sum. Memray flamegraphs for the programs run before and after the change can be seen below.
![memray-before](https://github.com/DUNE/ndlar_flow/assets/151683118/b1caeefa-ecfe-4e53-8e0f-071b71ce92b5)
![memray-after](https://github.com/DUNE/ndlar_flow/assets/151683118/978c6954-12e1-466d-8da0-1299167e92b9)
