### PR TITLE
Feature/ehinkle require same iogroup hit merging

### DIFF
--- a/src/proto_nd_flow/reco/charge/calib_hit_merger.py
+++ b/src/proto_nd_flow/reco/charge/calib_hit_merger.py
@@ -152,6 +152,7 @@ class CalibHitMerger(H5FlowStage):
             same_channel = (
                 (new_hits['z'][..., :-1] == new_hits['z'][..., 1:])
                 & (new_hits['y'][..., :-1] == new_hits['y'][..., 1:])
+                & (new_hits['io_group'][..., :-1] == new_hits['io_group'][..., 1:])
             )
 
             # flag valid hits if they are on the same channel and are close in time


### PR DESCRIPTION
Adding requirement that merged hits must have the same `io_group` in `calib_prompt_hits`.