### PR TITLE
Numpy v2 casting bugfix

### DIFF
--- a/src/proto_nd_flow/reco/charge/charge2light.py
+++ b/src/proto_nd_flow/reco/charge/charge2light.py
@@ -131,8 +131,8 @@ class Charge2LightAssociation(H5FlowStage):
         unix_ts_start = charge_unix_ts.min()
         unix_ts_end = charge_unix_ts.max()  
         
-        if self.light_unix_ts_start >= unix_ts_end + self.unix_ts_window or \
-           self.light_unix_ts_end <= unix_ts_start - self.unix_ts_window:
+        if float(self.light_unix_ts_start) >= float(unix_ts_end) + float(self.unix_ts_window) or \
+           float(self.light_unix_ts_end) <= float(unix_ts_start) - float(self.unix_ts_window):
             # no overlap, short circuit
             return np.empty((0, 2), dtype=int)
 

--- a/src/proto_nd_flow/reco/light/hit_finder.py
+++ b/src/proto_nd_flow/reco/light/hit_finder.py
@@ -211,7 +211,7 @@ class WaveformHitFinder(H5FlowStage):
             peak_sample_index = np.clip(peaks[-1].reshape(-1, 1)
                                         + np.arange(-self.near_samples + 1, self.near_samples + 2), 0, self.nsamples - 1)
             peak_samples = wvfms[peaks[:-1] + (peak_sample_index,)]
-            peak_sum = np.sum(peak_samples.astype(int), axis=-1)
+            peak_sum = np.sum(peak_samples, axis=-1)
             # create hit spline
             peak_spline = scipy.interpolate.CubicSpline(
                 np.arange(-self.near_samples, self.near_samples + 1),


### PR DESCRIPTION
Fix numpy v2 related casting bugs:
1. No need for casting peak_samples as int in light hit finder
2. Explicit casting of uint - int to float in charge to light matching (fixes charge light matching references, see below)
```
>>> import h5py
>>> fin =  h5py.File("ndlar_flow/test_final.FLOW.hdf5")
>>> print(fin['charge/events/ref/light/events/']['ref_region'][0:len(fin['charge/events/data'])])
[(  0,   1) (  1,   2) (  2,   3) (  3,   4) (  4,   5) (  5,   6)
 (  6,   7) (  7,   8) (  8,   9) (  9,  10) ( 10,  11) ( 11,  12)
 ( 12,  13) ( 13,  14) ( 14,  15) ( 15,  16) ( 16,  17) ( 17,  18)
 ( 18,  19) ( 19,  20) ( 20,  21) ( 21,  22) ( 22,  23) ( 23,  24)
 ( 24,  25) ( 25,  26) ( 26,  27) ( 27,  28) ( 28,  29) ( 29,  30)
 ( 30,  31) ( 31,  32) ( 32,  33) ( 33,  34) ( 34,  35) ( 35,  36)
 ( 36,  37) ( 37,  38) ( 38,  39) ( 39,  40) ( 40,  41) ( 41,  42)
 ( 42,  43) ( 43,  44) ( 44,  45) ( 45,  46) ( 46,  47) ( 47,  48)
 ( 48,  49) ( 49,  50) ( 50,  51) ( 51,  52) ( 52,  53) ( 53,  54)
 ( 54,  55) ( 55,  56) ( 56,  57) ( 57,  58) ( 58,  59) ( 59,  60)
 ( 60,  61) ( 61,  62) ( 62,  63) ( 63,  64) ( 64,  65) ( 65,  66)
 ( 66,  67) ( 67,  68) ( 68,  69) ( 69,  70) ( 70,  71) ( 71,  72)
 ( 72,  73) ( 73,  74) ( 74,  75) ( 75,  76) ( 76,  77) ( 77,  78)
 ( 78,  79) ( 79,  80) ( 80,  81) ( 81,  82) ( 82,  83) ( 83,  84)
 ( 84,  85) ( 85,  86) ( 86,  87) ( 87,  88) ( 88,  89) ( 89,  90)
 ( 90,  91) ( 91,  92) ( 92,  93) ( 93,  94) ( 94,  95) ( 95,  96)
 ( 96,  97) ( 97,  98) ( 98,  99) ( 99, 100) (100, 101) (101, 102)
 (102, 103) (103, 104) (104, 105) (105, 106) (106, 107) (107, 108)
 (108, 109) (109, 110) (110, 111) (111, 112) (112, 113) (113, 114)
 (114, 115) (115, 116) (116, 117) (117, 118) (118, 119) (119, 120)
 (120, 121) (121, 122) (122, 123) (123, 124) (124, 125) (125, 126)
 (126, 127) (127, 128) (128, 129) (129, 130) (130, 131) (131, 132)
 (132, 133) (133, 134) (134, 135) (135, 136) (136, 137) (137, 138)
 (138, 139) (139, 140) (140, 141) (141, 142) (142, 143) (143, 144)
 (144, 145) (145, 146) (146, 147) (147, 148) (148, 149) (149, 150)
 (150, 151) (151, 152) (152, 153) (153, 154) (154, 155) (155, 156)
 (156, 157) (157, 158) (158, 159) (159, 160) (160, 161) (161, 162)
 (162, 163) (163, 164) (164, 165) (165, 166) (166, 167) (167, 168)
 (168, 169) (169, 170) (170, 171) (171, 172) (172, 173) (173, 174)
 (174, 175) (175, 176) (176, 177) (177, 178) (178, 179) (179, 180)
 (180, 181) (181, 182) (182, 183) (183, 184) (184, 185) (185, 186)
 (186, 187)]
>>> print(fin['light/events/ref/charge/events/']['ref_region'][0:len(fin['light/events/data'])])
[(  0,   1) (  1,   2) (  2,   3) (  3,   4) (  4,   5) (  5,   6)
 (  6,   7) (  7,   8) (  8,   9) (  9,  10) ( 10,  11) ( 11,  12)
 ( 12,  13) ( 13,  14) ( 14,  15) ( 15,  16) ( 16,  17) ( 17,  18)
 ( 18,  19) ( 19,  20) ( 20,  21) ( 21,  22) ( 22,  23) ( 23,  24)
 ( 24,  25) ( 25,  26) ( 26,  27) ( 27,  28) ( 28,  29) ( 29,  30)
 ( 30,  31) ( 31,  32) ( 32,  33) ( 33,  34) ( 34,  35) ( 35,  36)
 ( 36,  37) ( 37,  38) ( 38,  39) ( 39,  40) ( 40,  41) ( 41,  42)
 ( 42,  43) ( 43,  44) ( 44,  45) ( 45,  46) ( 46,  47) ( 47,  48)
 ( 48,  49) ( 49,  50) ( 50,  51) ( 51,  52) ( 52,  53) ( 53,  54)
 ( 54,  55) ( 55,  56) ( 56,  57) ( 57,  58) ( 58,  59) ( 59,  60)
 ( 60,  61) ( 61,  62) ( 62,  63) ( 63,  64) ( 64,  65) ( 65,  66)
 ( 66,  67) ( 67,  68) ( 68,  69) ( 69,  70) ( 70,  71) ( 71,  72)
 ( 72,  73) ( 73,  74) ( 74,  75) ( 75,  76) ( 76,  77) ( 77,  78)
 ( 78,  79) ( 79,  80) ( 80,  81) ( 81,  82) ( 82,  83) ( 83,  84)
 ( 84,  85) ( 85,  86) ( 86,  87) ( 87,  88) ( 88,  89) ( 89,  90)
 ( 90,  91) ( 91,  92) ( 92,  93) ( 93,  94) ( 94,  95) ( 95,  96)
 ( 96,  97) ( 97,  98) ( 98,  99) ( 99, 100) (100, 101) (101, 102)
 (102, 103) (103, 104) (104, 105) (105, 106) (106, 107) (107, 108)
 (108, 109) (109, 110) (110, 111) (111, 112) (112, 113) (113, 114)
 (114, 115) (115, 116) (116, 117) (117, 118) (118, 119) (119, 120)
 (120, 121) (121, 122) (122, 123) (123, 124) (124, 125) (125, 126)
 (126, 127) (127, 128) (128, 129) (129, 130) (130, 131) (131, 132)
 (132, 133) (133, 134) (134, 135) (135, 136) (136, 137) (137, 138)
 (138, 139) (139, 140) (140, 141) (141, 142) (142, 143) (143, 144)
 (144, 145) (145, 146) (146, 147) (147, 148) (148, 149) (149, 150)
 (150, 151) (151, 152) (152, 153) (153, 154) (154, 155) (155, 156)
 (156, 157) (157, 158) (158, 159) (159, 160) (160, 161) (161, 162)
 (162, 163) (163, 164) (164, 165) (165, 166) (166, 167) (167, 168)
 (168, 169) (169, 170) (170, 171) (171, 172) (172, 173) (173, 174)
 (174, 175) (175, 176) (176, 177) (177, 178) (178, 179) (179, 180)
 (180, 181) (181, 182) (182, 183) (183, 184) (184, 185) (185, 186)
 (186, 187)]
```