### PR TITLE
Extended Time Window From Billy

### DIFF
--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -409,6 +409,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
     '''
     default_window = 1820 * 1.1
     default_rollover_ticks = 1E7
+    default_extended_event_dt = 70 #This is for accounting the fact that the trigger packet can potentially arrive 7 microseconds later than the beam spill
     default_trig_io_grp = 1     # -1 -> all io groups
     
     default_build_off_beam_events=False
@@ -424,6 +425,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
         self.off_beam_window = params.get('off_beam_window', self.default_off_beam_window)
         self.off_beam_threshold = params.get('off_beam_threshold', self.default_off_beam_threshold)
         self.VALIDATE_HACK = params.get('VALIDATE_HACK', False)
+        self.extended_event_dt = params.get('extended_event_dt', self.default_extended_event_dt)
 
         self.event_buffer = np.empty((0,))  
         self.event_buffer_unix_ts = np.empty((0,), dtype='u8')
@@ -485,7 +487,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
         # Only used if off-beam events are built later with unused packets
         used_mask = np.zeros( len(unix_ts) ) < -1
         for i, start_idx in enumerate(beam_trigger_idxs):
-            this_trig_time = ts[start_idx]
+            this_trig_time = ts[start_idx]-self.extended_event_dt # FIXME might need to consider roll-over 
             start_times.append(this_trig_time)
             # FIXME & (ts % 1E7 != 0) is a hot fix for PPS signal
             hotfix_mask = (ts % 1E7 != 0) | ((ts % 1E7 == 0) & trig_mask)

--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -487,7 +487,8 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
         # Only used if off-beam events are built later with unused packets
         used_mask = np.zeros( len(unix_ts) ) < -1
         for i, start_idx in enumerate(beam_trigger_idxs):
-            this_trig_time = ts[start_idx]-self.extended_event_dt # FIXME might need to consider roll-over 
+            this_trig_time = ts[start_idx]-self.extended_event_dt
+            this_trig_time += self.rollover_ticks if this_trig_time < 0 else 0 # Considered Roll-Over Issue
             start_times.append(this_trig_time)
             # FIXME & (ts % 1E7 != 0) is a hot fix for PPS signal
             hotfix_mask = (ts % 1E7 != 0) | ((ts % 1E7 == 0) & trig_mask)

--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -409,7 +409,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
     '''
     default_window = 1820 * 1.1
     default_rollover_ticks = 1E7
-    default_extended_event_dt = 70 #This is for accounting the fact that the trigger packet can potentially arrive 7 microseconds later than the beam spill
+    default_shifted_event_dt = 70 #This is for accounting the fact that the trigger packet can potentially arrive 7 microseconds later than the beam spill
     default_trig_io_grp = 1     # -1 -> all io groups
     
     default_build_off_beam_events=False
@@ -425,7 +425,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
         self.off_beam_window = params.get('off_beam_window', self.default_off_beam_window)
         self.off_beam_threshold = params.get('off_beam_threshold', self.default_off_beam_threshold)
         self.VALIDATE_HACK = params.get('VALIDATE_HACK', False)
-        self.extended_event_dt = params.get('extended_event_dt', self.default_extended_event_dt)
+        self.shifted_event_dt = params.get('shifted_event_dt', self.default_shifted_event_dt)
 
         self.event_buffer = np.empty((0,))  
         self.event_buffer_unix_ts = np.empty((0,), dtype='u8')
@@ -487,7 +487,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
         # Only used if off-beam events are built later with unused packets
         used_mask = np.zeros( len(unix_ts) ) < -1
         for i, start_idx in enumerate(beam_trigger_idxs):
-            this_trig_time = ts[start_idx]-self.extended_event_dt
+            this_trig_time = ts[start_idx]-self.shifted_event_dt
             this_trig_time += self.rollover_ticks if this_trig_time < 0 else 0 # Considered Roll-Over Issue
             start_times.append(this_trig_time)
             # FIXME & (ts % 1E7 != 0) is a hot fix for PPS signal

--- a/yamls/proto_nd_flow/reco/charge/RawEventGeneratorData.yaml
+++ b/yamls/proto_nd_flow/reco/charge/RawEventGeneratorData.yaml
@@ -18,4 +18,4 @@ params:
     rollover_ticks: 10000000 # PPS = 1e7 ticks
     build_off_beam_events : True
     VALIDATE_HACK : False
-    extended_event_dt : 70
+    shifted_event_dt : 70

--- a/yamls/proto_nd_flow/reco/charge/RawEventGeneratorData.yaml
+++ b/yamls/proto_nd_flow/reco/charge/RawEventGeneratorData.yaml
@@ -18,3 +18,4 @@ params:
     rollover_ticks: 10000000 # PPS = 1e7 ticks
     build_off_beam_events : True
     VALIDATE_HACK : False
+    extended_event_dt : 70


### PR DESCRIPTION
Adding an additional parameter that allows us to extend the time window before the trigger packet happening. This parameter is defaulted at 70 ticks. Details see the split event update in 
https://indico.fnal.gov/event/67862/