### PR TITLE
Feature/adc droop calib

### DIFF
--- a/src/proto_nd_flow/reco/charge/calib_noise_filter.py
+++ b/src/proto_nd_flow/reco/charge/calib_noise_filter.py
@@ -6,7 +6,7 @@ import sys
 from h5flow.core import H5FlowStage, resources
 from sklearn.neighbors import KernelDensity
 from pickle import dump, load
-
+import json
 from proto_nd_flow.reco.charge.calib_prompt_hits import CalibHitBuilder
 
 ## Some useful functions for the filter classes
@@ -28,12 +28,41 @@ class low_current_filter:
         Filters out hits with low indunced current. Specify threshold to remove hitsnwith Q<threshold
     '''
 
-    def __init__(self, threshold=6.):
+    def __init__(self, threshold=1., channel_threshold_file=''):
         self.threshold = float(threshold)
         print('using threshold:', self.threshold)
-    def filter(self, hits):
-        return hits['Q']<self.threshold
+        self.channel_threshold_file=channel_threshold_file
+        try:
+            with open(self.channel_threshold_file, 'r') as fi:
+                self.channel_thresholds=json.load(fi)
+        except:
+            self.channel_thresholds={}
+            print('Unable to open channel threshold file! {}\nProceeding with default threshold for all channels.'.format(self.channel_threshold_file))
+    
+    def unique_channel_id(self, d):
+        return ((d['io_group'].astype(int)*1000+d['io_channel'].astype(int))*1000 \
+            + d['chip_id'].astype(int))*100 + d['channel_id'].astype(int)
 
+    def filter(self, hits, default_threshold=5.0):
+        
+        #Get channel by channel thresholds
+        tile_id = resources['Geometry'].tile_id[hits['io_group'],hits['io_channel']]
+        hit_uniqueid = self.unique_channel_id(hits)
+
+        charge_above_threshold = np.ones(hits.shape)*99.
+
+        unique_ids, counts = np.unique(hit_uniqueid, return_counts=True)
+        threshold=default_threshold
+        for u in unique_ids:
+            if not str(u) in self.channel_thresholds.keys():
+                print('No threshold found for channel {}! Using default threshold of {} ke-!'.format(u, default_threshold))
+            else:
+                threshold = self.channel_thresholds[str(u)] 
+            m = hit_uniqueid==u
+            charge_above_threshold[m] = hits[m]['Q']-threshold
+
+        return charge_above_threshold<self.threshold
+        
 class correlated_post_trigger_filter:
     '''
         Module 2 (v2b) specific filter for noise from charge injection from ADC reference instability
@@ -194,6 +223,7 @@ class CalibNoiseFilter(H5FlowStage):
         mc_hit_frac_dset_name = 'mc_truth/calib_final_hit_backtrack',
         low_current_filter__threshold=6.0,
         hot_pixel_filter__max_n_hits=35,
+        low_current_filter__channel_threshold_file='data/proto_nd_flow/thresholds_2x2.json',
         filter_function_names = ['hot_pixel_filter']
         )
     valid_filter_functions = ['low_current_filter', 'correlated_post_trigger_filter', 'hot_pixel_filter']
@@ -239,7 +269,7 @@ class CalibNoiseFilter(H5FlowStage):
         old_ids = hits.data['id'].copy()[...,np.newaxis]
         old_id_mask = hits.mask['id'].copy()[...,np.newaxis]
         filter_mask = self.default_filter_function(new_hits)
-
+        
         for f in self.filter_functions:
             filter_mask = filter_mask | f.filter(hits)
 

--- a/src/proto_nd_flow/reco/charge/calib_noise_filter.py
+++ b/src/proto_nd_flow/reco/charge/calib_noise_filter.py
@@ -94,12 +94,12 @@ class correlated_post_trigger_filter:
                 
                 chan_nhit = np.sum(m)
                 
-                m = np.logical_and(m, hits['Q']<self.RANGE_Q[1])
-                m = np.logical_and(m, hits['Q']>self.RANGE_Q[0])
+                m = np.logical_and(m, hits['Q_raw']<self.RANGE_Q[1])
+                m = np.logical_and(m, hits['Q_raw']>self.RANGE_Q[0])
                 
                 ts = hits['ts_pps'][m].astype(int)-min_ts
-                qs = hits['Q'][m]
-                sumqs = np.array([np.sum(hits['Q'][m])]*ts.shape[0])
+                qs = hits['Q_raw'][m]
+                sumqs = np.array([np.sum(hits['Q_raw'][m])]*ts.shape[0])
                 if np.sum(m)<1: continue
                 
                 lrs[m] = self.get_lr(n_chip_hits, np.array([ts, qs, sumqs]).transpose(), cc, chan_nhit)

--- a/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
+++ b/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
@@ -62,7 +62,8 @@ class CalibHitBuilder(H5FlowStage):
             io_channel     u8, io channel ID (related to PACMAN number & PACMAN UART Number)
             chip_id        u8, chip_id on tile 
             channel_id     u8, channel_id on single chip (0-63)
-            Q              f8, hit charge [ke-]
+            Q_raw          f8, hit charge [ke-] (uncalibrated for ADC droop)
+            Q              f8, calibrated hit charge with ADC droop corrections
             E              f8, hit energy [MeV]
 
     '''
@@ -90,6 +91,7 @@ class CalibHitBuilder(H5FlowStage):
         ('io_channel', 'u8'),
         ('chip_id', 'u8'),
         ('channel_id', 'u8'),
+        ('Q_raw', 'f8'),
         ('Q', 'f8'),
         ('E', 'f8')
     ])
@@ -111,6 +113,7 @@ class CalibHitBuilder(H5FlowStage):
         self.vcm_mv = params.get('vcm_mv', 478.1)
         self.adc_counts = params.get('adc_counts', 256)
         self.gain = params.get('gain', 4.522)
+        self.adc_droop_calibration = params.get('adc_droop_calibration', False)
 
     def init(self, source_name):
         super(CalibHitBuilder, self).init(source_name)
@@ -122,6 +125,7 @@ class CalibHitBuilder(H5FlowStage):
         events_data = cache[self.events_dset_name]
         packets_data = cache[self.packets_dset_name]
         packets_index = cache[self.packets_index_name]
+        
         if resources['RunData'].is_mc:
             packet_frac_bt = cache['packet_frac_backtrack']
             packet_seg_bt = cache['packet_seg_backtrack']
@@ -160,9 +164,11 @@ class CalibHitBuilder(H5FlowStage):
                                     packets_dset=self.packets_dset_name,
                                     t0_dset=self.t0_dset_name,
                                     pedestal_file=self.pedestal_file,
-                                    configuration_file=self.configuration_file
+                                    configuration_file=self.configuration_file,
+                                    adc_droop_calibration=self.adc_droop_calibration
                                     )
-
+        
+        
         # then set up new datasets
         self.data_manager.create_dset(self.calib_hits_dset_name, dtype=self.calib_hits_dtype)
         if has_mc_truth:
@@ -246,7 +252,13 @@ class CalibHitBuilder(H5FlowStage):
             calib_hits_arr['chip_id'] = packets_arr['chip_id']
             calib_hits_arr['channel_id'] = packets_arr['channel_id']
             hits_charge = self.charge_from_dataword(packets_arr['dataword'], vref, vcm, ped, self.adc_counts, self.gain) # ke-
-            calib_hits_arr['Q'] = hits_charge # ke-
+            calib_hits_arr['Q_raw'] = hits_charge # ke-
+            if self.adc_droop_calibration: 
+                hits_charge_calibrated = self.charge_from_dataword_corrected(packets_arr['dataword'], packets_arr['timestamp'], hit_uniqueid, vref, vcm, ped, self.adc_counts, self.gain) # ke- 
+                calib_hits_arr['Q'] = hits_charge_calibrated # ke-
+            else:
+                calib_hits_arr['Q'] = hits_charge
+
             #FIXME supply more realistic dEdx in the recombination; also apply measured electron lifetime
             calib_hits_arr['E'] = hits_charge * (1000 * units.e) / resources['LArData'].ionization_recombination(mode=2,dEdx=2) * (resources['LArData'].ionization_w / units.MeV) # MeV
             if has_mc_truth:
@@ -282,6 +294,51 @@ class CalibHitBuilder(H5FlowStage):
         if has_mc_truth:
             self.data_manager.write_ref(self.calib_hits_dset_name,self.mc_hit_frac_dset_name,np.c_[calib_hits_arr['id'],calib_hits_arr['id']])
 
+    def get_vref_vcm_correction(self, t, t_hits, tau_rc_vref = 5000.0, impulse_vref=-0.5, tau_rc_vcm=4000.0, impulse_vcm=0.4):
+        return self.exp_sum( t, t_hits, impulse_vref, tau_rc_vref), self.exp_sum( t, t_hits, impulse_vcm, tau_rc_vcm  )
+
+    def exp_sum(self, t, ts, amps, taus ):
+        mask = ts <= t
+        ts = ts[ mask ]
+        if not type(amps) in [int, float, np.float64]:
+            amps = amps[mask]
+            taus = taus[mask]
+        if np.sum(mask)==0:
+            return 0
+        return np.sum( amps * np.exp( -1*(t - ts)/taus  )  ) 
+
+    
+    def charge_from_dataword_corrected(self, dw, ts, uid, vref, vcm, ped, adc_counts, gain):
+        #accounts for changes in vref, vcm due to nonlinearities in adc (excessive load on vref/vcm bypass capacitors on tile PCB) 
+
+        # Find chips that had 
+        chip_uid = (uid // 100)*100
+        chips, counts = np.unique(chip_uid, return_counts=True)
+        
+        vref_arr = np.full( dw.shape, vref  )
+        vcm_arr =  np.full( dw.shape, vcm   )
+        
+        for chip in chips[counts > 1]:
+     
+            mask = chip_uid==chip
+
+            chip_ts = ts[mask]
+
+            #collect all vref, vcm corrections for hits on this chip
+            vref_corrs = np.zeros( chip_ts.shape )
+            vcm_corrs = np.zeros( chip_ts.shape )
+            
+            for ihit, t in enumerate(chip_ts):
+
+                vref_corr, vcm_corr = self.get_vref_vcm_correction(t, chip_ts)
+
+                vref_corrs[ihit] = vref_corr
+                vcm_corrs[ihit] = vcm_corr
+
+            vcm_arr[mask] += vcm_corrs
+            vref_arr[mask] += vref_corrs
+             
+        return (dw / adc_counts * (vref_arr - vcm_arr) + vcm_arr - ped) / gain
 
     @staticmethod
     def charge_from_dataword(dw, vref, vcm, ped, adc_counts, gain):

--- a/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
+++ b/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
@@ -294,7 +294,7 @@ class CalibHitBuilder(H5FlowStage):
         if has_mc_truth:
             self.data_manager.write_ref(self.calib_hits_dset_name,self.mc_hit_frac_dset_name,np.c_[calib_hits_arr['id'],calib_hits_arr['id']])
 
-    def get_vref_vcm_correction(self, t, t_hits, tau_rc_vref = 5000.0, impulse_vref=-0.5, tau_rc_vcm=4000.0, impulse_vcm=0.4):
+    def get_vref_vcm_correction(self, t, t_hits, tau_rc_vref = 4400.0, impulse_vref=-0.352, tau_rc_vcm=1460.0, impulse_vcm=0.352):
         return self.exp_sum( t, t_hits, impulse_vref, tau_rc_vref), self.exp_sum( t, t_hits, impulse_vcm, tau_rc_vcm  )
 
     def exp_sum(self, t, ts, amps, taus ):

--- a/yamls/proto_nd_flow/reco/charge/CalibHitBuilderData.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibHitBuilderData.yaml
@@ -28,4 +28,7 @@ params:
   adc_counts: 256
   gain: 4.522 #datasheet: 4 #measurement(?): 4.522
 
+  #flag to perform ADC droop calibration
+  adc_droop_calibration: True
+
   pedestal_file: '/global/common/software/dune/mkramer/devel/flow4pedestal/reference-cold-pedestal-2024_06_05_08_28_19_CDTevd_ped.tile_id.decimal.json'

--- a/yamls/proto_nd_flow/reco/charge/CalibNoiseFilter.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibNoiseFilter.yaml
@@ -21,9 +21,9 @@ params:
   events_dset_name: 'charge/events'
   hits_name: 'charge/calib_prompt_hits'
   filter_function_names: ['hot_pixel_filter','correlated_post_trigger_filter', 'low_current_filter'] #which filter functions to apply (this is an ordered list, but all filters will be "OR'd")
-
+  low_current_filter__channel_threshold_file: 'data/proto_nd_flow/thresholds_2x2.json'
   #params specific to each cut
-  low_current_filter__threshold: 6.0 #
+  low_current_filter__threshold: 1 #
   hot_pixel_filter__max_n_hits: 35 
     #hot_pixel_filter__max_n_hits: 
     # - maximum number of hits on a channel in single event before filtering all hits from channel

--- a/yamls/proto_nd_flow/resources/RunDataData.yaml
+++ b/yamls/proto_nd_flow/resources/RunDataData.yaml
@@ -3,6 +3,8 @@ path: proto_nd_flow.resources.run_data
 params:
   path: 'run_info'
   runlist_file: 'data/proto_nd_flow/runlist-2x2-mcexample.txt'
+  channel_threshold_file: 'data/proto_nd_flow/thresholds_2x2.json'
+
   #runlist_file: 'data/module0_flow/runlist-mod0-run2.txt'
   # download link: https://portal.nersc.gov/project/dune/data/Module0/runlist.txt
   # download link: https://portal.nersc.gov/project/dune/data/Module0-Run2/runlist.txt

--- a/yamls/proto_nd_flow/workflows/charge/final_calibration_data.yaml
+++ b/yamls/proto_nd_flow/workflows/charge/final_calibration_data.yaml
@@ -17,7 +17,7 @@ raw_events:
   path: h5flow.modules
   dset_name: 'charge/raw_events'
   params:
-    chunk_size: 32
+    chunk_size: 30
 
 calib_noise_filter:
   !include yamls/proto_nd_flow/reco/charge/CalibNoiseFilter.yaml

--- a/yamls/proto_nd_flow/workflows/charge/final_calibration_mc.yaml
+++ b/yamls/proto_nd_flow/workflows/charge/final_calibration_mc.yaml
@@ -17,7 +17,7 @@ raw_events:
   path: h5flow.modules
   dset_name: 'charge/raw_events'
   params:
-    chunk_size: 32
+    chunk_size: 30
 
 calib_noise_filter:
   !include yamls/proto_nd_flow/reco/charge/CalibNoiseFilter.yaml


### PR DESCRIPTION
Two main updates in this branch: an implementation of "ADC droop" calibration, and an update to the threshold filter to use channel-by-channel extracted thresholds.

**ADC "droop" Calibration**

Firstly, a calibration for the ADC instability ("ADC droop") effect is implemented. 

A brief summary of what is included is below, and some more details on the effect and the mechanism can be found here: https://indico.fnal.gov/event/67027/contributions/307766/attachments/184558/253844/workshop%2001_24_25-1.pdf

For each chip in an event, the values of the chip V_ref and V_cm for the ADC are simulated (as a function of time and the number of hits in the event). The model for these voltages is a "step" impulse with an exponential decay back to baseline. This includes 4 parameters (2 for each V_cm and V_ref): the impulse size and the RC constant of the exponential decay. The initial values for these parameters are taken from bench top tests with the LArPix tiles. However, these tests were performed at room temperature, and the behavior of the ASIC, as well as the R and C values for the relevant board components will vary by ~10-20% from room temperature to LAr. Thus, in order to ensure the parameters used accurately reflect data, a systematic scan of events is performed. The procedure is described below:

1. Fix values for the parameters and perform the calibration.
2. For each chip and for each event, select "at threshold" hits (hits with dataword <5ke-, which is approx. the channel threshold )
3. Fit a line to hit charge vs. time. For a proper calibration, these "at threshold" hits should be ~flat in time.
4. Histogram the slope for each chip. 
5. Iterate on parameters with a maximum 10% deviation from benchtop values until the distribution of slopes is unbiased from 0.

A sample line fit and the histograms of line slopes for raw and calibrated data are included below.

<img width="726" alt="Screen Shot 2025-02-20 at 6 44 24 PM" src="https://github.com/user-attachments/assets/7cb79a77-ba8d-4e3d-acdb-2a4803429bf9" />
<img width="574" alt="Screen Shot 2025-02-20 at 6 45 40 PM" src="https://github.com/user-attachments/assets/30b87204-ecdb-4ec2-a429-d4e5f263093e" />

The calibrated value is stored in the field "Q" for both calib_final_hits and calib_prompt_hits. The uncalibrated value is also stored in the field "Q_raw" for both of these.

**Threshold Filter** 

Rather than assuming a uniform threshold (essentially giving a hard cut off of data word below the fixed value), a channel by channel threshold value is used. These thresholds are specified in a json file of the same format implemented in larnd-sim. It should be confirmed that changes in the encoding of these thresholds stay consistent between larnd-sim and ndlar_flow.

Some distributions for. a sample data file are included below showing Q_raw for unfiltered hits ("raw"), Q for unfiltered hits ("calibrated") , and Q for filtered hits ("final").

![Figure 5](https://github.com/user-attachments/assets/e9623a4b-a93a-4a54-ad5a-9616610724f2)


Note that, although all of these changes are being pushed together, its very simple to disentangle the effects of each in further analysis. Because Q_raw is stored, its simple to study just the impact of the new filter. Similarly, the impact of the calibration alone can be understood by using calib_prompt_hits.

