### PR TITLE
setting default behavior to save truth references

### DIFF
--- a/src/proto_nd_flow/reco/charge/raw_event_generator.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_generator.py
@@ -86,7 +86,7 @@ class RawEventGenerator(H5FlowGenerator):
     default_mc_tracks_dset_name = 'mc_truth/segments'
     default_mc_trajectories_dset_name = 'mc_truth/trajectories'
     default_mc_packet_fraction_dset_name = 'mc_truth/packet_fraction'
-    default_truth_ref = False
+    default_truth_ref = True
 
     raw_event_dtype = np.dtype([
         ('id', 'u8'),

--- a/yamls/proto_nd_flow/reco/charge/RawEventGeneratorMC.yaml
+++ b/yamls/proto_nd_flow/reco/charge/RawEventGeneratorMC.yaml
@@ -9,6 +9,7 @@ params:
   mc_tracks_dset_name: 'mc_truth/segments'
   buffer_size: 3000000 #38400
   nhit_cut: 1
+  truth_ref: True
   sync_noise_cut: [100, 11000000] # Stephen says no need to cut > first 10 usec
   sync_noise_cut_enabled: True
   event_builder_class: 'ExtTrigRawEventBuilder' #'SymmetricWindowRawEventBuilder'


### PR DESCRIPTION
This is to match what we have had in past 2x2 productions. Analyzers are using some of these references, and we should present proposals for significant format changes like this to the wider group before including in productions. This addresses some comments in #162, although the underlying option may still not have been tested.