### PR TITLE
Use the "ADC Droop" corrected charge for calib_prompt_hit energy

### DIFF
--- a/scripts/proto_nd_scripts/run_proto_nd_flow_example.sh
+++ b/scripts/proto_nd_scripts/run_proto_nd_flow_example.sh
@@ -20,11 +20,11 @@ H5FLOW_CMD='h5flow'
 #H5FLOW_CMD='srun -n32 h5flow'
 
 # run all stages
-WORKFLOW1='yamls/proto_nd_flow/workflows/charge/charge_event_building.yaml'
-WORKFLOW2='yamls/proto_nd_flow/workflows/charge/charge_event_reconstruction.yaml'
-WORKFLOW3='yamls/proto_nd_flow/workflows/combined/combined_reconstruction.yaml'
-WORKFLOW4='yamls/proto_nd_flow/workflows/charge/prompt_calibration.yaml'
-WORKFLOW5='yamls/proto_nd_flow/workflows/charge/final_calibration.yaml'
+WORKFLOW1='yamls/proto_nd_flow/workflows/charge/charge_event_building_data.yaml'
+WORKFLOW2='yamls/proto_nd_flow/workflows/charge/charge_event_reconstruction_data.yaml'
+WORKFLOW3='yamls/proto_nd_flow/workflows/combined/combined_reconstruction_data.yaml'
+WORKFLOW4='yamls/proto_nd_flow/workflows/charge/prompt_calibration_data.yaml'
+WORKFLOW5='yamls/proto_nd_flow/workflows/charge/final_calibration_data.yaml'
 
 HERE=`pwd`
 #cd ndlar_flow

--- a/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
+++ b/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
@@ -265,7 +265,7 @@ class CalibHitBuilder(H5FlowStage):
                 calib_hits_arr['Q'] = hits_charge
 
             #FIXME supply more realistic dEdx in the recombination; also apply measured electron lifetime
-            calib_hits_arr['E'] = hits_charge * (1000 * units.e) / resources['LArData'].ionization_recombination(mode=2,dEdx=2) * (resources['LArData'].ionization_w / units.MeV) # MeV
+            calib_hits_arr['E'] = calib_hits_arr['Q'] * (1000 * units.e) / resources['LArData'].ionization_recombination(mode=2,dEdx=2) * (resources['LArData'].ionization_w / units.MeV) # MeV
             #if has_mc_truth:
             #    true_recomb = resources['LArData'].ionization_recombination(mode=2,dEdx=packet_seg_bt_arr['dEdx'])
             #    calib_hits_arr['E_true_recomb_elife'] = np.divide(hits_charge.reshape((hits_charge.shape[0],1)) * (1000 * units.e), true_recomb, out=np.zeros_like(true_recomb), where=true_recomb!=0) / resources['LArData'].charge_reduction_lifetime(t_drift=drift_t_true) * (resources['LArData'].ionization_w / units.MeV) # MeV

--- a/src/proto_nd_flow/reco/charge/raw_event_generator.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_generator.py
@@ -465,21 +465,17 @@ class RawEventGenerator(H5FlowGenerator):
         if not events:
             return H5FlowGenerator.EMPTY
 
-        # apply nhit cut
-        def nhit_filter(x):
-
-            event = x[0]
-
-            mask_disabled_channels = np.isin(event[['io_group', 'io_channel', 'chip_id', 'channel_id']], resources['Geometry'].disabled_channels)
-
-            mask_disabled_chips = np.isin(event[['io_group', 'io_channel', 'chip_id']], resources['Geometry'].disabled_chips)
-            
-            return (~(mask_disabled_channels | mask_disabled_chips)).sum() >= self.nhit_cut
-
         if self.is_mc:
+            # apply disable channel mask
+            def nhit_filter(x):
+                event = x[0]
+                mask_disabled_channels = np.isin(event[['io_group', 'io_channel', 'chip_id', 'channel_id']], resources['Geometry'].disabled_channels)
+                mask_disabled_chips = np.isin(event[['io_group', 'io_channel', 'chip_id']], resources['Geometry'].disabled_chips)
+                return (~(mask_disabled_channels | mask_disabled_chips)).sum() >= self.nhit_cut
+
             nhit_filtered = list(filter(nhit_filter, zip(events, event_unix_ts, event_mc_assn)))
         else:
-            nhit_filtered = list(filter(nhit_filter, zip(events, event_unix_ts)))
+            nhit_filtered = list(filter(lambda x: len(x[0]) >= self.nhit_cut, zip(events, event_unix_ts)))
 
         if len(nhit_filtered):
             if self.is_mc:


### PR DESCRIPTION
At the moment we are not applying a real electron lifetime nor recombination correction, so we expect the hit charge and energy to be 1-to-1. @noeroy noticed this was not the case since the adc droop correction was implemented (#171). This PR fixes that issue, and was tested on the same datafile in #171. Along the way, I needed to fix the disabled channel mask to only be applied on MC and not data.

![image](https://github.com/user-attachments/assets/82ab1b49-b77b-4e2c-9498-fd466af89ca1)
