### PR TITLE
Load geometry in the first stage for FSD

### DIFF
--- a/yamls/fsd_flow/workflows/charge/charge_event_building_mc.yaml
+++ b/yamls/fsd_flow/workflows/charge/charge_event_building_mc.yaml
@@ -9,6 +9,7 @@ flow:
 
 resources:
   - !include yamls/fsd_flow/resources/RunDataMC.yaml
+  - !include yamls/fsd_flow/resources/GeometryMC.yaml
 
 
 raw_event_generator: # groups time-sorted data packets from larpix datalog files


### PR DESCRIPTION
Responding to Andrew's alert: 

> Is there a disabled channel/chip map for the FSD? The latest commits in nd-flow apparently now require a disabled channel file to not crash when processing MC simulation.

Below is my Slack response:

> Ah ok, I see the issue. 
> With the dead channel implementation, you now have to add the line 
> \- !include yamls/fsd_flow/resources/GeometryMC.yaml
> in 
> yamls/fsd_flow/workflows/charge/charge_event_building_mc.yaml .
> We need to load the Geometry resource in the early stages now because we  need to know what channels are disabled to properly implement the nhit filter for each event, even though there's no actual filtering of individual hits in RawEventGenerator.yaml .
> Even if there's no disabled channels, the Geometry resource has to be loaded for flow to know whether there are disabled channels or not.