### PR TITLE
Bugfix hit finder crash due peak position at the end of the waveform

### DIFF
--- a/src/proto_nd_flow/reco/light/hit_finder.py
+++ b/src/proto_nd_flow/reco/light/hit_finder.py
@@ -236,10 +236,8 @@ class WaveformHitFinder(H5FlowStage):
         noise = self.get_noise_threshold(wvfms)
         peaks = self.interaction_finder(wvfms,noise)
         peaks = np.where(peaks)
-        if np.any(peaks[3] >= wvfms.shape[-1]): 
-            print("Warning: Some peak indices exceed valid range.")
-            peaks = tuple(np.clip(p, 0, wvfms.shape[-1]-1) for p in peaks) 
-        peak_max = wvfms[..., 1:][peaks]  # waveform value at each peak
+
+        peak_max = wvfms[..., :][peaks]  # waveform value at each peak
         threshold_mask = peak_max >=self.threshold[peaks[1:-1]].ravel()
 
         if np.count_nonzero(threshold_mask):

--- a/src/proto_nd_flow/reco/light/hit_finder.py
+++ b/src/proto_nd_flow/reco/light/hit_finder.py
@@ -311,7 +311,7 @@ class WaveformHitFinder(H5FlowStage):
                 hit_data['chan'] = wvfm_det[peaks[:3]].ravel()
                 hit_data['pos'] = [np.array(resources['Geometry'].sipm_abs_pos[(adc,chan)][0]) for adc, chan in zip(peaks[1].ravel(),wvfm_det[peaks[:3]].ravel())]
             hit_data['ns'] = wvfm_align['ns'][peaks[0]].ravel()
-            hit_data['sample_idx'] = peaks[-1].ravel() + 1
+            hit_data['sample_idx'] = peaks[-1].ravel()
 
             # =================================================================
             # 2022-05-17 kvtsang
@@ -331,7 +331,7 @@ class WaveformHitFinder(H5FlowStage):
                 )
 
             hit_data['busy_ns'] = (
-                (peaks[-1] + 1 - align_sample_idx[peaks[:3]]).ravel() 
+                (peaks[-1] - align_sample_idx[peaks[:3]]).ravel() 
                 * self.sample_rate
             )
             hit_data['samples'] = peak_samples.reshape(-1, 2 * self.near_samples + 1)


### PR DESCRIPTION
Fixed issue from the peak finder where the peak position was found.

The previous implementation was a leftover from the previous peak finder, while the new implementation looks for the sample value > threshold directly.

 Modification selects the peak in the total waveform and removes the need of shifting back the peak position afterwards. 

I ran on the failed run Matt sent me `/pscratch/sd/d/dunepro/mkramer/logs/Reflow_2x2_v9/flow/beam/july8_2024/nominal_hv/packet-0050017-2024_07_09_13_46_00_CDT.log` for test and haven't seen any crash. 

I don't see any modification on the time resolution, with the same distribution as before.

