### PR TITLE
Modifying CRS ADC reference voltage settings to operated values

### DIFF
--- a/yamls/fsd_flow/reco/charge/CalibHitBuilderData.yaml
+++ b/yamls/fsd_flow/reco/charge/CalibHitBuilderData.yaml
@@ -22,6 +22,10 @@ params:
   calib_hits_dset_name: 'charge/calib_prompt_hits'
 
   # configuration parameters
+  vref_mv: 1504.2
+  vcm_mv: 573.3
+  adc_counts: 256
+  gain: 4.522
 
   pedestal_file: '/global/common/software/dune/inputs/FSD/pedestals/packet-pedestal-2024_11_12_03_29_26_CET.pedestal.json'
   #pedestal_file: 'data/module0_flow/datalog_2021_04_02_19_00_46_CESTevd_ped.json'


### PR DESCRIPTION
Based on the average VDDA setting for FSD tiles being 1720 mV (1750 mV at the top and 1690 mV at the bottom) and `vref_dac: 223` and `vcm_dac: 85`, where `v_mv = vdda_mv*(v_dac/255)`.