### PR TITLE
Update `buffer_size` in `RawEventGeneratorMC.yaml` for NDLAr

### DIFF
--- a/yamls/ndlar_flow/reco/charge/RawEventGeneratorMC.yaml
+++ b/yamls/ndlar_flow/reco/charge/RawEventGeneratorMC.yaml
@@ -8,7 +8,7 @@ params:
   # configuration parameters
   mc_tracks_dset_name: 'mc_truth/segments'
   truth_ref: False
-  buffer_size: 1152000 #38400
+  buffer_size: 11520000 #38400
   nhit_cut: 1
   sync_noise_cut: [1000000, 11000000] # 1e6 cut based on Brooke's study
   sync_noise_cut_enabled: True


### PR DESCRIPTION
Bumping the `buffer_size` by a factor of 10. This is based on interactive tests performed on a full FHC spill (rock + NDLAr-fid and -antifid) file with 10^15 POT. The actual factor from these tests was ~5 so giving a factor of 2 head-room here.