### PR TITLE
changing v_drift parameter in lar data to correspond to simulated value

### DIFF
--- a/yamls/fsd_flow/resources/LArData.yaml
+++ b/yamls/fsd_flow/resources/LArData.yaml
@@ -15,3 +15,4 @@ params:
   birks_kb: 0.0486 # g/cm2/MeV Amoruso, et al NIM A 523 (2004) 275
   #: Average energy expended per ion pair in LAr in :math:`eV` from Phys. Rev. A 10, 1452
   W_ion: 23.6
+  v_drift: 1.648 # mm/us

--- a/yamls/proto_nd_flow/resources/LArData.yaml
+++ b/yamls/proto_nd_flow/resources/LArData.yaml
@@ -15,3 +15,4 @@ params:
   birks_kb: 0.0486 # g/cm2/MeV Amoruso, et al NIM A 523 (2004) 275
   #: Average energy expended per ion pair in LAr in :math:`eV` from Phys. Rev. A 10, 1452
   W_ion: 23.6
+  v_drift: 1.648 # mm/us


### PR DESCRIPTION
@russellphysics pointed out an inconsistency in our [simulated drift speed](https://github.com/DUNE/larnd-sim/blob/2a24bb4c281f24394c66ad2f1e2d86bde1cb015c/larndsim/consts/detector.py#L24) and the one we apply when processing the data here. In `ndlar_flow`, we calculate the expected drift speed based on the applied drift field based on a model unless a value is explicity given in LArData.yaml (as this PR introduces). I did not separate the LArData.yaml file for MC and for Data, so this simulated value of 1.648 mm/us will be applied to both. Analyses are in progress to measure v_drift from the data, and it will be helpful to have an explicit "hardcoded" value in the meantime.

For the record: the drift velocity model predicts 0.1597 mm/us, about 3% slower than the simulated value.