### PR TITLE
Minor event-building improvements

### DIFF
--- a/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
+++ b/src/proto_nd_flow/reco/charge/calib_prompt_hits.py
@@ -211,7 +211,25 @@ class CalibHitBuilder(H5FlowStage):
                     hit_t0[first_index:last_index] = np.full(n_not_masked,t0)
                     first_index += n_not_masked
 
-            drift_t = raw_hits_arr['ts_pps'] - hit_t0 #ticks
+            drift_t = raw_hits_arr['ts_pps'].astype('f8') - hit_t0 #ticks
+
+            # If this event crosses a PPS reset, and if the t0 is post-reset,
+            # then correct the drift time for pre-reset hits. Identify those
+            # hits as those having an absurdly large (positive) drift_t.
+            before_sync_mask = drift_t > 1e5
+            # For those hits, subtract out the rollover period.
+            drift_t[before_sync_mask] -= resources['RunData'].rollover_ticks
+            # TODO: Instead of the nominal rollover_ticks, use the actual
+            # timestamps of the SYNC. Need to wire in those SYNC timestamps and
+            # the io group of each hit (or use the average SYNC timestamps; see
+            # ave_pps_ts in timestamp_corrector.py)
+
+            # Now handle the case where the t0 is pre-reset. The post-reset hits
+            # will have absurdly negative drift_t.
+            after_sync_mask = drift_t < -1e5
+            # This time we add the rollover period instead of subtracting.
+            drift_t[after_sync_mask] += resources['RunData'].rollover_ticks
+
             drift_d = drift_t * (resources['LArData'].v_drift * resources['RunData'].crs_ticks) / units.cm # convert mm -> cm
             x = resources['Geometry'].get_drift_coordinate(packets_arr['io_group'],packets_arr['io_channel'],drift_d)
 

--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -200,7 +200,7 @@ class TimeDeltaRawEventBuilder(RawEventBuilder):
 
         # sort packets to fix 512 bug
         packets = np.append(self.event_buffer, packets) if len(self.event_buffer) else packets
-        sorted_idcs = np.argsort(packets, order='timestamp')
+        sorted_idcs = np.argsort(packets, order='timestamp', kind='stable')
         packets = packets[sorted_idcs]
         unix_ts = np.append(self.event_buffer_unix_ts, unix_ts)[sorted_idcs] if len(self.event_buffer_unix_ts) else unix_ts[sorted_idcs]
         if mc_assn is not None:
@@ -340,7 +340,7 @@ class SymmetricWindowRawEventBuilder(RawEventBuilder):
         if ts is None:
             ts = self.unroll_timestamps(packets)
 
-        sorted_idcs = np.argsort(ts)
+        sorted_idcs = np.argsort(ts, kind='stable')
         ts = ts[sorted_idcs]
         packets = packets[sorted_idcs]
         unix_ts = np.append(self.event_buffer_unix_ts, unix_ts)[sorted_idcs] if len(self.event_buffer_unix_ts) else unix_ts[sorted_idcs]
@@ -509,14 +509,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
             return ([], []) if mc_assn is None else ([], [], [])
 
         ts = self.unroll_timestamps(packets)
-        sorted_idcs = np.argsort(ts)
-        ts = ts[sorted_idcs]
 
-        packets = packets[sorted_idcs]
-        unix_ts = unix_ts[sorted_idcs]
-        if mc_assn is not None:
-            mc_assn = mc_assn[sorted_idcs]
-        
         trig_mask = packets['packet_type'] == 7
         if self.trig_io_grp != [-1]:
             iog_masks = [packets['io_group'] == iog for iog in self.trig_io_grp]

--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -350,7 +350,8 @@ class SymmetricWindowRawEventBuilder(RawEventBuilder):
         # calculate time distance between hits
         min_ts, max_ts = np.min(ts), np.max(ts)
         bin_edges = np.linspace(min_ts - 1, max_ts + 1, int((max_ts - min_ts + 2) // self.window))
-        hist, bin_edges = np.histogram(ts, bins=bin_edges)
+        ts_data = ts[packets['packet_type'] == 0]
+        hist, bin_edges = np.histogram(ts_data, bins=bin_edges)
 
         # find high correlation regions
         event_mask = (hist > self.threshold)

--- a/yamls/proto_nd_flow/reco/charge/RawEventGeneratorData.yaml
+++ b/yamls/proto_nd_flow/reco/charge/RawEventGeneratorData.yaml
@@ -16,4 +16,5 @@ params:
     window: 2000 # ExtTrigRawEventBuilder - 2000, more than one drift for 500V/cm
     trig_io_grp: -1
     build_off_beam_events : True
+    off_beam_threshold : 20
     shifted_event_dt : -70


### PR DESCRIPTION
- Handle the case where a PPS reset occurs mid-event, whether that happens before or after the t0-determining "trigger". This eliminates the issue of hits with insanely large drift coordinates.
- In the SymmetricWindow and (currently unused old-school) TimeDelta raw event builders, use "stable" sorts to avoid reordering of packets in the (non-ExtTrig) event builder. This reduces the differences between `charge/packets` and the underlying packet file.
- In the SymmetricWindow builder, only consider *data* packets when deciding whether we have enough packets to form an event
- Bump the 2x2 `off_beam_threshold` to 20 to improve the signal-to-garbage ratio in the flow files. This reduces the event count from O(100k) to O(10k) for a representative 2x2 file (first sandbox file), while retaining decent Q/L trigger matching:

```
Total charge trigger matching: 7750/7876 (0.9840)
Total charge event matching: 7750/9072 (0.8543)
Total light event matching: 7750/7839 (0.9886)
```