### PR TITLE
Make fix to remove duplicate triggers in 2x2 run2

### DIFF
--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -515,11 +515,7 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
             iog_masks = [packets['io_group'] == iog for iog in self.trig_io_grp]
             trig_mask &= np.logical_or.reduce(iog_masks)
         
-        trig_ts = ts[trig_mask]
-        if np.any(np.diff(trig_ts) == 3): # account for repeated triggers caused by 2x2 run2 trigger issue per-10/28/25
-            trigger_idcs = np.concatenate(([0], np.where(np.diff(trig_ts) != 3)[0]+1))
-        else:
-            trigger_idcs = np.where(trig_mask)[0]
+        trigger_idcs = np.where(trig_mask)[0]
             
         events = []
         event_unix_ts = []

--- a/src/proto_nd_flow/reco/charge/raw_event_builder.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_builder.py
@@ -514,8 +514,13 @@ class ExtTrigRawEventBuilder(RawEventBuilder):
         if self.trig_io_grp != [-1]:
             iog_masks = [packets['io_group'] == iog for iog in self.trig_io_grp]
             trig_mask &= np.logical_or.reduce(iog_masks)
-        trigger_idcs = np.where(trig_mask)[0]
-
+        
+        trig_ts = ts[trig_mask]
+        if np.any(np.diff(trig_ts) == 3): # account for repeated triggers caused by 2x2 run2 trigger issue per-10/28/25
+            trigger_idcs = np.concatenate(([0], np.where(np.diff(trig_ts) != 3)[0]+1))
+        else:
+            trigger_idcs = np.where(trig_mask)[0]
+            
         events = []
         event_unix_ts = []
         event_mc_assn = [] if mc_assn is not None else None

--- a/src/proto_nd_flow/reco/charge/raw_event_generator.py
+++ b/src/proto_nd_flow/reco/charge/raw_event_generator.py
@@ -447,6 +447,16 @@ class RawEventGenerator(H5FlowGenerator):
         if self.is_mc:
             mc_assn = mc_assn[mask]
 
+        pkts_indices = np.arange(len(packet_buffer))
+        trig_mask = packet_buffer['packet_type'] == 7
+        trig_ts = packet_buffer['timestamp'][trig_mask]
+
+        # handle when there are duplicate triggers -- specifically designed to handle the 2x2 run2 problem where repeat pulses have precisely 3 ticks between them
+        ts_diff = np.diff(trig_ts)
+        if np.any(ts_diff == 3):
+            trigger_idcs = np.concatenate(([0], np.where(ts_diff != 3)[0]+1))
+            packet_buffer = packet_buffer[(packet_buffer['packet_type'] != 7) | np.isin(pkts_indices, pkts_indices[trig_mask][trigger_idcs])]
+            
         # find unix timestamp groups
         ts_mask = packet_buffer['packet_type'] == 4
         ts_grps = np.split(packet_buffer, np.argwhere(ts_mask).ravel())


### PR DESCRIPTION
I included some lines in `raw_event_generator.py` to filter out repeat trigger pulses due to the 2x2 run2 data taken before 10/28/25 when a hardware fix was implemented. There are groups of 33 triggers for every one trigger, so the code keeps only the first trigger of each group. For data taken after the fix it shouldn't impact anything.