### PR TITLE
Configure light hit finder for ndlar_flow

### DIFF
--- a/yamls/ndlar_flow/reco/light/SumHitFinder.yaml
+++ b/yamls/ndlar_flow/reco/light/SumHitFinder.yaml
@@ -26,3 +26,6 @@ params:
   pe_weight: 1.0
   rising_edge: False
   local_maxima: True
+  prompt_window: 200.0
+  long_window: 3200.0
+  tick_duration: 16.0


### PR DESCRIPTION
When trying to run the default Q+L flow workflows for NDLAr, we ran into an issue with the configuration of  `src/proto_nd_flow/reco/light/hit_finder.py`.

See error:
```
ndlar_flow/src/proto_nd_flow/reco/light/hit_finder.py", line 148, in calculate_fprompt
    prompt_bins = int(np.ceil(prompt_window_ns / tick_duration_ns))
                              ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'NoneType'
```

Looks like
```
prompt_window: 200.0
long_window: 3200.0
tick_duration: 16.0
```
had been configured in 
```
yamls/proto_nd_flow/reco/light/SumHitFinder.yaml
```
but not in
```
yamls/ndlar_flow/reco/light/SumHitFinder.yaml
```

This PR sets the three parameters in the latter file.