### PR TITLE
Modifications to Allow Hit Merging Step to be a Default Workflow in NDLAr Flow

### DIFF
--- a/yamls/ndlar_flow/workflows/charge/merged_calibration_mc.yaml
+++ b/yamls/ndlar_flow/workflows/charge/merged_calibration_mc.yaml
@@ -1,0 +1,24 @@
+# Generates the mid-level event built data for charge data (i.e. hits and
+# external triggers)
+
+# This went in yamls/ndlar_flow/workflows/charge/merged_calibration_mc.yaml
+
+flow:
+  source: raw_events
+  stages: [calib_hit_merger]
+  drop: []
+
+resources:
+  - !include yamls/ndlar_flow/resources/RunDataMC.yaml
+  - !include yamls/ndlar_flow/resources/LArData.yaml
+  - !include yamls/ndlar_flow/resources/GeometryMC.yaml
+
+raw_events:
+  classname: H5FlowDatasetLoopGenerator
+  path: h5flow.modules
+  dset_name: 'charge/raw_events'
+  params:
+    chunk_size: 32
+
+calib_hit_merger:
+  !include yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml

--- a/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
@@ -15,6 +15,6 @@ params:
   max_merge_steps: 50 # max number of iterations when merging
                        # adjacent packets in time on the same channel
   # outputs
-  merged_name: 'charge/calib_final_hits'
-  mc_hit_frac_dset_name: 'mc_truth/calib_final_hit_backtrack'
+  merged_name: 'charge/calib_merged_hits'
+  mc_hit_frac_dset_name: 'mc_truth/calib_merged_hit_backtrack'
 

--- a/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
+++ b/yamls/proto_nd_flow/reco/charge/CalibHitMerger.yaml
@@ -10,7 +10,7 @@ params:
   # inputs
   events_dset_name: 'charge/events'
   hits_name: 'charge/calib_prompt_hits'
-  max_contrib_segments: 400
+  max_contrib_segments: 600
   merge_cut: 65 # merge hits with delta t < merge_cut [CRS ticks]
   max_merge_steps: 50 # max number of iterations when merging
                        # adjacent packets in time on the same channel


### PR DESCRIPTION
This PR should be merged in tandem with [PR 68](https://github.com/DUNE/ND_Production/pull/68) in `ND_Production`. Here a workflow yaml is added and hit dataset names are changed to be distinct from the final calibration already run.
